### PR TITLE
Update model_zoo.py warning to be more precise

### DIFF
--- a/src/coastseg/zoo_model.py
+++ b/src/coastseg/zoo_model.py
@@ -1184,10 +1184,10 @@ class Zoo_Model:
         # if configs do not exist then raise an error and do not save the session
         if not file_utilities.validate_config_files_exist(roi_directory):
             logger.warning(
-                f"Config files config.json or config_gdf.geojson do not exist in roi directory {roi_directory}"
+                f"Config files config.json and config_gdf.geojson do not exist in roi directory {roi_directory}"
             )
             raise FileNotFoundError(
-                f"Config files config.json or config_gdf.geojson do not exist in roi directory {roi_directory}"
+                f"Config files config.json and config_gdf.geojson do not exist in roi directory {roi_directory}"
             )
         # modify the config.json to only have the ROI ID that was used and save to session directory
         roi_id = file_utilities.extract_roi_id(roi_directory)


### PR DESCRIPTION
If both config.json and config_gdf.geojson is not present, code will fail. Thus the warning renamed "or" to "and".
