### PR TITLE
Release v2.0.4

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5887,8 +5887,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: coastseg
-  version: 2.0.3
-  sha256: 9cf65e8de9109f0c841ee66335be172c5425273d593f5b0ded000a14ea0ee098
+  version: 2.0.4
+  sha256: 73f502f4006a04757ef4b9fd86b397c0af9a78f44ed4b41d7dce6412ede6eb6f
   requires_dist:
   - aiohttp
   - onnxruntime

--- a/pixi.lock
+++ b/pixi.lock
@@ -388,7 +388,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/c3/1c/f06ad85180e7dd9855aa5ede901bfc2be858d7bee17d4e978a14c0ecec14/astropy-7.2.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/21/14/125eb772fc1e8985d4cdc46a7e81a61009eae02492ef62488c53245c9d9f/astropy_iers_data-0.2026.4.1.15.5.49-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/15/d3/9b93e33a0664978d3692b05c2f75e68593dc936d81a328889a7a0f20fbf3/coastsat_package-0.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/0add87bcffd9f9a5d31b99a7c1d1cf70fa14d532a9e7cc760be7b76a5282/coastsat_package-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a5/97/446fdd7bd98dbaf6b8d255ea2d510862df42cdc6edad0888d07a4dc89711/earthengine_api-1.7.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/86/a00ea4596780ef3f0721c1f073c0c5ae992da4f35cf12f0d8c92d19267a6/google_api_core-2.30.1-py3-none-any.whl
@@ -794,7 +794,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/b4/6d/6330a844bad8dfc4875e0f2fa1db1fee87837ba9805aa8a8d048c071363a/astropy-7.2.0-cp311-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/21/14/125eb772fc1e8985d4cdc46a7e81a61009eae02492ef62488c53245c9d9f/astropy_iers_data-0.2026.4.1.15.5.49-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/15/d3/9b93e33a0664978d3692b05c2f75e68593dc936d81a328889a7a0f20fbf3/coastsat_package-0.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/0add87bcffd9f9a5d31b99a7c1d1cf70fa14d532a9e7cc760be7b76a5282/coastsat_package-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a5/97/446fdd7bd98dbaf6b8d255ea2d510862df42cdc6edad0888d07a4dc89711/earthengine_api-1.7.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/86/a00ea4596780ef3f0721c1f073c0c5ae992da4f35cf12f0d8c92d19267a6/google_api_core-2.30.1-py3-none-any.whl
@@ -1200,7 +1200,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/a6/ba/3418133ba144dfcd1530bca5a6b695f4cdd21a8abaaa2ac4e5450d11b028/astropy-7.2.0-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/21/14/125eb772fc1e8985d4cdc46a7e81a61009eae02492ef62488c53245c9d9f/astropy_iers_data-0.2026.4.1.15.5.49-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/15/d3/9b93e33a0664978d3692b05c2f75e68593dc936d81a328889a7a0f20fbf3/coastsat_package-0.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/0add87bcffd9f9a5d31b99a7c1d1cf70fa14d532a9e7cc760be7b76a5282/coastsat_package-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a5/97/446fdd7bd98dbaf6b8d255ea2d510862df42cdc6edad0888d07a4dc89711/earthengine_api-1.7.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/86/a00ea4596780ef3f0721c1f073c0c5ae992da4f35cf12f0d8c92d19267a6/google_api_core-2.30.1-py3-none-any.whl
@@ -1600,7 +1600,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: https://files.pythonhosted.org/packages/ec/bc/f4378f586dd63902c37d16f68f35f7d555b3b32e08ac6b1d633eb0a48805/astropy-7.2.0-cp311-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/21/14/125eb772fc1e8985d4cdc46a7e81a61009eae02492ef62488c53245c9d9f/astropy_iers_data-0.2026.4.1.15.5.49-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/15/d3/9b93e33a0664978d3692b05c2f75e68593dc936d81a328889a7a0f20fbf3/coastsat_package-0.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/0add87bcffd9f9a5d31b99a7c1d1cf70fa14d532a9e7cc760be7b76a5282/coastsat_package-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a5/97/446fdd7bd98dbaf6b8d255ea2d510862df42cdc6edad0888d07a4dc89711/earthengine_api-1.7.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/86/a00ea4596780ef3f0721c1f073c0c5ae992da4f35cf12f0d8c92d19267a6/google_api_core-2.30.1-py3-none-any.whl
@@ -2021,7 +2021,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/c3/1c/f06ad85180e7dd9855aa5ede901bfc2be858d7bee17d4e978a14c0ecec14/astropy-7.2.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/21/14/125eb772fc1e8985d4cdc46a7e81a61009eae02492ef62488c53245c9d9f/astropy_iers_data-0.2026.4.1.15.5.49-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/15/d3/9b93e33a0664978d3692b05c2f75e68593dc936d81a328889a7a0f20fbf3/coastsat_package-0.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/0add87bcffd9f9a5d31b99a7c1d1cf70fa14d532a9e7cc760be7b76a5282/coastsat_package-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a5/97/446fdd7bd98dbaf6b8d255ea2d510862df42cdc6edad0888d07a4dc89711/earthengine_api-1.7.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/86/a00ea4596780ef3f0721c1f073c0c5ae992da4f35cf12f0d8c92d19267a6/google_api_core-2.30.1-py3-none-any.whl
@@ -2431,7 +2431,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/b4/6d/6330a844bad8dfc4875e0f2fa1db1fee87837ba9805aa8a8d048c071363a/astropy-7.2.0-cp311-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/21/14/125eb772fc1e8985d4cdc46a7e81a61009eae02492ef62488c53245c9d9f/astropy_iers_data-0.2026.4.1.15.5.49-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/15/d3/9b93e33a0664978d3692b05c2f75e68593dc936d81a328889a7a0f20fbf3/coastsat_package-0.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/0add87bcffd9f9a5d31b99a7c1d1cf70fa14d532a9e7cc760be7b76a5282/coastsat_package-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a5/97/446fdd7bd98dbaf6b8d255ea2d510862df42cdc6edad0888d07a4dc89711/earthengine_api-1.7.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/86/a00ea4596780ef3f0721c1f073c0c5ae992da4f35cf12f0d8c92d19267a6/google_api_core-2.30.1-py3-none-any.whl
@@ -2841,7 +2841,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/a6/ba/3418133ba144dfcd1530bca5a6b695f4cdd21a8abaaa2ac4e5450d11b028/astropy-7.2.0-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/21/14/125eb772fc1e8985d4cdc46a7e81a61009eae02492ef62488c53245c9d9f/astropy_iers_data-0.2026.4.1.15.5.49-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/15/d3/9b93e33a0664978d3692b05c2f75e68593dc936d81a328889a7a0f20fbf3/coastsat_package-0.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/0add87bcffd9f9a5d31b99a7c1d1cf70fa14d532a9e7cc760be7b76a5282/coastsat_package-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a5/97/446fdd7bd98dbaf6b8d255ea2d510862df42cdc6edad0888d07a4dc89711/earthengine_api-1.7.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/86/a00ea4596780ef3f0721c1f073c0c5ae992da4f35cf12f0d8c92d19267a6/google_api_core-2.30.1-py3-none-any.whl
@@ -3244,7 +3244,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: https://files.pythonhosted.org/packages/ec/bc/f4378f586dd63902c37d16f68f35f7d555b3b32e08ac6b1d633eb0a48805/astropy-7.2.0-cp311-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/21/14/125eb772fc1e8985d4cdc46a7e81a61009eae02492ef62488c53245c9d9f/astropy_iers_data-0.2026.4.1.15.5.49-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/15/d3/9b93e33a0664978d3692b05c2f75e68593dc936d81a328889a7a0f20fbf3/coastsat_package-0.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/0add87bcffd9f9a5d31b99a7c1d1cf70fa14d532a9e7cc760be7b76a5282/coastsat_package-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a5/97/446fdd7bd98dbaf6b8d255ea2d510862df42cdc6edad0888d07a4dc89711/earthengine_api-1.7.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/86/a00ea4596780ef3f0721c1f073c0c5ae992da4f35cf12f0d8c92d19267a6/google_api_core-2.30.1-py3-none-any.whl
@@ -5849,35 +5849,52 @@ packages:
   - pkg:pypi/cloudpickle?source=hash-mapping
   size: 27353
   timestamp: 1765303462831
-- pypi: https://files.pythonhosted.org/packages/15/d3/9b93e33a0664978d3692b05c2f75e68593dc936d81a328889a7a0f20fbf3/coastsat_package-0.4.6-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/bf/4b/0add87bcffd9f9a5d31b99a7c1d1cf70fa14d532a9e7cc760be7b76a5282/coastsat_package-0.5.0-py3-none-any.whl
   name: coastsat-package
-  version: 0.4.6
-  sha256: 682637a0fe2fc350bbbf1ac3850d0090c25fe74a3a74a929e85809e2a804b087
+  version: 0.5.0
+  sha256: 1a62414c42de45ed3f9c30c34e74ba8bf549fe671957e20e66a8876abc5e3312
   requires_dist:
-  - scikit-image
-  - earthengine-api>=0.1.304
-  - jupyterlab>=3.0.0
-  - geopandas
-  - matplotlib
   - astropy
-  - tqdm
-  - importlib-resources
-  - pyqt5
-  - scipy
-  - numpy
+  - earthengine-api>=0.1.304
+  - geopandas
+  - google-auth
   - imageio
+  - importlib-resources
+  - joblib
+  - matplotlib
+  - numpy>=2
+  - onnxruntime
+  - pandas
+  - pillow
+  - pooch
+  - pyqt5
+  - pytz
+  - requests
+  - scikit-image>=0.25
   - scikit-learn
-  requires_python: '>=3.8'
+  - scipy
+  - shapely
+  - tqdm
+  - ipykernel ; extra == 'notebook'
+  - jupyterlab>=3 ; extra == 'notebook'
+  - pytest>=8 ; extra == 'test'
+  - pytest-cov>=5 ; extra == 'test'
+  - build>=1.2 ; extra == 'dev'
+  - pytest>=8 ; extra == 'dev'
+  - pytest-cov>=5 ; extra == 'dev'
+  - ruff>=0.9 ; extra == 'dev'
+  - twine>=5 ; extra == 'dev'
+  requires_python: '>=3.10'
 - pypi: ./
   name: coastseg
   version: 2.0.3
-  sha256: 225dd28fa1a3774a92b56f0981772736d28dd9ceadf3c7bfc986614b52cf1b5d
+  sha256: 9cf65e8de9109f0c841ee66335be172c5425273d593f5b0ded000a14ea0ee098
   requires_dist:
   - aiohttp
   - onnxruntime
   - chardet
   - dask
-  - coastsat-package>=0.3.3
+  - coastsat-package>=0.5.0
   - geojson
   - geopandas
   - h5py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 name = "coastseg"
 readme = "README.md"
-version = "2.0.3"
+version = "2.0.4"
 #these dependencies are the core dependencies of the package necessary for the coastsat workflow and the core functionality. Pixi reads these as pypi dependencies
 classifiers = [
   "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
   "onnxruntime",
   "chardet",
   "dask",
-  "coastsat-package>=0.3.3",
+  # 0.5.0 is the first release with the enhanced SAR workflow
+  "coastsat-package>=0.5.0",
   "geojson",
   "geopandas",
   "h5py",
@@ -70,7 +71,8 @@ coastseg = {path = ".", editable = true}
 # Note: pytmd is purposely not included here because it causes conflicts when installed from conda-forge
 [tool.pixi.dependencies]
 netcdf4 = "*" # prefer to have this installed from conda-forge because it can cause conflicts on MacOS when installed from pip
-onnxruntime = "*"
+# Pin the CPU build of onnx to avoid heavy GPU based cuda installation
+onnxruntime = { version = "*", build = "*cpu*" }
 aiohttp = "*"
 area = "*"
 chardet = "*"

--- a/segmentation_workflow/how_to_run_models.md
+++ b/segmentation_workflow/how_to_run_models.md
@@ -1,5 +1,10 @@
 # How to Run the Segmentation Workflow
 
+> **Sentinel-1 (SAR) is not run from here.** This workflow is for the optical
+> SegFormer models only. The SAR model is ONNX and runs in the main CoastSeg
+> environment — use `4_zoo_workflow_SAR.py` from the repository root. See
+> `run_SAR_model.txt` in this directory.
+
 ## 1. Install the Environment
 
 Choose one option.

--- a/segmentation_workflow/run_SAR_model.txt
+++ b/segmentation_workflow/run_SAR_model.txt
@@ -1,0 +1,53 @@
+The Sentinel-1 (SAR) model is NOT run from this directory.
+================================================================================
+
+run_zoo_segmentation_models.py cannot run it. That script loads Keras `.h5`
+SegFormer weights with TensorFlow, and this environment contains only
+tensorflow and transformers. The SAR model is a `.onnx` model that needs
+onnxruntime and gdal, neither of which is installed here. It also reads the raw
+dual-polarization GeoTIFFs rather than the RGB preview jpgs this script expects.
+
+Run it from the main CoastSeg environment instead. Nothing extra to install.
+
+  From the repository root:
+
+      python 4_zoo_workflow_SAR.py
+
+  Edit `input_directory` and `session_name` at the top of that script first.
+
+  Or call it directly:
+
+      from coastseg import zoo_model
+
+      zoo = zoo_model.Zoo_Model()
+      zoo.set_settings(img_type="SAR", model_type="SAR_segmentation_model")
+      zoo.run_model_and_extract_shorelines(
+          r"CoastSeg\data\ID_...\jpg_files\preprocessed\RGB",
+          session_name="my_sar_session",
+      )
+
+  To segment without extracting shorelines, use the batch driver directly:
+
+      from coastseg import sar_model
+
+      sar_model.run_sar_segmentation(
+          roi_directory=r"CoastSeg\data\ID_...",
+          session_directory=r"CoastSeg\sessions\my_sar_session",
+          model_directory=r"CoastSeg\models\SAR_segmentation_model",
+      )
+
+Requirements
+--------------------------------------------------------------------------------
+The ROI must have been downloaded with BOTH the VV and VH polarizations. The
+model reads data/ID_.../S1/VV/*.tif and data/ID_.../S1/VH/*.tif and builds a
+[VV, VH, VV-VH] composite. ROIs downloaded before multi-polarization support
+have VV only and raise MissingPolarizationError -- re-download them.
+
+The model (~130 MB) downloads from Hugging Face on first use and is cached, so
+the first run is slower. To supply your own, put the `.onnx` in
+CoastSeg/models/SAR_segmentation_model or point `local_model_path` at it.
+
+The outputs are identical to this script's: `_predseg.png`, `_res.npz`,
+model_settings.json, model_info.json and segmentation_summary.json, written flat
+into the session directory. That is deliberate, so shoreline extraction is the
+same downstream regardless of which segmenter produced them.

--- a/src/coastseg/coastseg_map.py
+++ b/src/coastseg/coastseg_map.py
@@ -1821,6 +1821,17 @@ class CoastSeg_Map:
             "apply_cloud_mask": True,
             "image_size_filter": True,
             "drop_intersection_pts": False,
+            "sentinel_1_properties": common.get_default_sentinel_1_properties(),
+            # Sentinel-1 land/water segmentation. "model" runs coastsat's trained ONNX
+            # segmenter; "otsu" reverts to thresholding, which is what CoastSeg did
+            # before the model existed. Stated explicitly rather than left to coastsat's
+            # own default so it round-trips through config.json and shows in the UI.
+            "sar_segmentation": "model",
+            "sar_water_threshold": 0.5,
+            # "" means let coastsat resolve the default model, which it downloads from
+            # Hugging Face into its pooch cache on first use. When set, it is stored
+            # relative to the CoastSeg directory -- see common.relativize_sar_model_path.
+            "sar_model_path": "",
             "coastseg_version": __version__,
         }
 
@@ -1842,6 +1853,12 @@ class CoastSeg_Map:
 
         for key, value in self.default_settings.items():
             self.settings.setdefault(key, value)
+
+        # Never persist an absolute path to the SAR model: config.json travels between
+        # machines. Idempotent, so it is safe to run on every call.
+        self.settings["sar_model_path"] = common.relativize_sar_model_path(
+            self.settings.get("sar_model_path", "")
+        )
 
         logger.info(f"Set Settings: {self.settings}")
         return self.settings.copy()

--- a/src/coastseg/common.py
+++ b/src/coastseg/common.py
@@ -1,4 +1,5 @@
 # Standard library imports
+import copy
 import glob
 import json
 import logging
@@ -43,6 +44,9 @@ from requests.exceptions import SSLError
 from shapely.geometry import LineString, MultiPoint, Point, Polygon, shape
 from shapely.ops import transform
 from tqdm.auto import tqdm
+
+from coastsat.SDS_download import DEFAULT_SENTINEL_1_PROPERTIES
+from coastsat.SDS_tools import SAR_POLARIZATIONS
 
 # Internal dependencies imports
 from coastseg import core_utilities, exceptions, file_utilities
@@ -396,6 +400,14 @@ def extract_roi_settings(
             "sat_list",
             "landsat_collection",
             "filepath",
+            # without these two, reloading a config silently drops them and the
+            # download falls back to coastsat's internal defaults
+            "sentinel_1_properties",
+            "include_T2",
+            # Sentinel-1 segmentation controls, read by coastsat's SDS_shoreline
+            "sar_segmentation",
+            "sar_water_threshold",
+            "sar_model_path",
         }
     if not roi_ids:
         roi_ids = json_data.get("roi_ids", [])
@@ -479,6 +491,80 @@ def get_missing_roi_dirs(
             missing_directories[roi_id] = sitename
 
     return missing_directories
+
+
+def get_default_sentinel_1_properties() -> Dict[str, Any]:
+    """Return the default Sentinel-1 acquisition properties.
+
+    VV and VH are both requested: the SAR segmentation model takes VV, VH and their
+    difference as its three channels, so a VH-only site cannot be segmented. A fresh
+    copy is returned each call so a caller storing it per ROI cannot alias the global.
+
+    Returns:
+        Dict[str, Any]: Sentinel-1 properties, including the requested polarizations.
+    """
+    return copy.deepcopy(dict(DEFAULT_SENTINEL_1_PROPERTIES))
+
+
+def relativize_sar_model_path(sar_model_path: str = "") -> str:
+    """Store a SAR model path relative to the CoastSeg base directory.
+
+    ``config.json`` and session folders get copied between machines. An absolute path
+    baked into one is dead everywhere else, and coastsat would then ``os.path.abspath``
+    a path that does not exist and fail to open the model. Storing it relative to the
+    CoastSeg directory keeps a session portable.
+
+    A path outside the CoastSeg tree cannot be made relative. It is kept verbatim rather
+    than rewritten silently changing a path the user typed is worse than an
+    unportable one  and a warning says so.
+
+    Args:
+        sar_model_path (str): Model path as supplied by the user. May be absolute,
+            relative, or empty.
+
+    Returns:
+        str: A path suitable for writing to ``config.json``, using POSIX separators so a
+        config written on Windows loads on Linux. Empty input returns empty, which means
+        "use coastsat's packaged model".
+    """
+    if not sar_model_path:
+        return ""
+
+    candidate = Path(sar_model_path)
+    if not candidate.is_absolute():
+        return candidate.as_posix()
+
+    try:
+        return candidate.relative_to(core_utilities.get_base_dir()).as_posix()
+    except ValueError:
+        logger.warning(
+            f"sar_model_path {sar_model_path} is outside the CoastSeg directory, so it "
+            "cannot be stored relatively. This session will not load on another machine."
+        )
+        return candidate.as_posix()
+
+
+def resolve_sar_model_path(sar_model_path: str = "") -> str:
+    """Turn a stored SAR model path into one coastsat can open.
+
+    The inverse of :func:`relativize_sar_model_path`. Relative paths resolve against the
+    CoastSeg base directory, *not* the current working directory  coastsat applies
+    ``os.path.abspath`` to whatever it receives, which would otherwise silently resolve
+    against wherever the notebook happens to be running.
+
+    Args:
+        sar_model_path (str): Model path as stored in the settings.
+
+    Returns:
+        str: An absolute path, or ``""`` to let coastsat fall back to its packaged model.
+    """
+    if not sar_model_path:
+        return ""
+
+    candidate = Path(sar_model_path)
+    if candidate.is_absolute():
+        return str(candidate)
+    return str(Path(core_utilities.get_base_dir()) / candidate)
 
 
 def create_new_config(roi_ids: list, settings: dict, roi_settings: dict) -> dict:
@@ -786,6 +872,10 @@ def load_settings(
         "min_chainage",
         "multiple_inter",
         "prc_multiple",
+        "sentinel_1_properties",
+        "sar_segmentation",
+        "sar_water_threshold",
+        "sar_model_path",
     },
     new_settings: dict = {},
 ) -> dict:
@@ -851,6 +941,18 @@ def update_roi_settings_with_global_settings(
     updated_roi_settings = update_roi_settings(
         updated_roi_settings, "min_roi_coverage", min_roi_coverage
     )
+
+    # Sentinel-1 polarizations. add_if_missing=True is required: ROI settings saved
+    # before multi-polarization support have no such key, and update_roi_settings skips
+    # keys that are absent, so those ROIs would stay VH-only forever.
+    sentinel_1_properties = global_settings.get("sentinel_1_properties")
+    if sentinel_1_properties:
+        updated_roi_settings = update_roi_settings(
+            updated_roi_settings,
+            "sentinel_1_properties",
+            copy.deepcopy(sentinel_1_properties),
+            add_if_missing=True,
+        )
 
     return updated_roi_settings
 
@@ -1016,7 +1118,9 @@ def filter_images_by_roi(roi_settings: Dict[str, Any]) -> None:
             logger.warning(f"Could not filter {ROI_jpg_location} did not exist")
             continue
         roi_gdf = gpd.GeoDataFrame(index=[0], geometry=[polygon], crs="EPSG:4326")
-        bad_images = filter_partial_images(roi_gdf, ROI_jpg_location)
+        bad_images = filter_partial_images(
+            roi_gdf, ROI_jpg_location, roi_directory=roi_location
+        )
         logger.info(f"Partial images filtered out: {bad_images}")
 
 
@@ -1065,6 +1169,7 @@ def filter_partial_images(
     directory: str,
     min_area_percentage: float = 0.40,
     max_area_percentage: float = 1.5,
+    roi_directory: str = "",
 ):
     """
     Filters images in a directory based on their area with respect to the area of the Region of Interest (ROI).
@@ -1093,8 +1198,11 @@ def filter_partial_images(
     """
     # low and high range are in km
     roi_area = get_roi_area(roi_gdf)
-    filter_images(
-        roi_area * min_area_percentage, roi_area * max_area_percentage, directory
+    return filter_images(
+        roi_area * min_area_percentage,
+        roi_area * max_area_percentage,
+        directory,
+        roi_directory=roi_directory,
     )
 
 
@@ -1146,7 +1254,11 @@ def get_satellite_name(filename: str) -> Optional[str]:
 
 
 def filter_images(
-    min_area: float, max_area: float, directory: str, output_directory: str = ""
+    min_area: float,
+    max_area: float,
+    directory: str,
+    output_directory: str = "",
+    roi_directory: str = "",
 ) -> List[str]:
     """
     Filters images in a given directory based on a range of acceptable areas and moves the filtered out
@@ -1163,6 +1275,10 @@ def filter_images(
         output_directory (str): The path to the directory where the bad images will be moved.
                                          If not provided, a new directory named 'bad' will be created
                                          inside the given directory.
+        roi_directory (str): The ROI's data directory, holding the per-satellite GeoTIFF
+                                         folders. When given, each scene's area is measured from its
+                                         GeoTIFF rather than its preview jpg. Required for Sentinel-1,
+                                         whose preview is a matplotlib figure and not a raster.
 
     Returns:
         List[str]: List of bad files that were moved.
@@ -1207,8 +1323,20 @@ def filter_images(
             continue
 
         filepath = os.path.join(directory, file)
-        # Calculate the area of the jpg
-        img_area = calculate_image_area(filepath, pixel_size_per_satellite[satname])
+        # Measure area using the GeoTIFF but not for S1
+        raster = find_source_raster(file, roi_directory)
+        if raster:
+            img_area = calculate_raster_area(raster, pixel_size_per_satellite[satname])
+        elif satname == "S1":
+            # if there is no tif to measure area then skip area calculation for S1
+            logger.warning(
+                f"No GeoTIFF found for {file}; skipping the size filter for it. "
+                "The Sentinel-1 preview is a figure, so its area cannot be measured."
+            )
+            continue
+        else:
+            img_area = calculate_image_area(filepath, pixel_size_per_satellite[satname])
+
         if img_area < min_area or (max_area is not None and img_area > max_area):
             bad_files.append(file)
 
@@ -1222,6 +1350,9 @@ def calculate_image_area(filepath: str, pixel_size: int) -> float:  #
     """
     Calculate the area of an image in square kilometers.
 
+    Only valid for a preview whose pixels are the raster's pixels. Sentinel-1 previews are
+    matplotlib figures, so use :func:`calculate_raster_area` on the GeoTIFF instead.
+
     Args:
         filepath (str): The path to the image file.
         pixel_size (int): The size of a pixel in the image in meters.
@@ -1234,6 +1365,88 @@ def calculate_image_area(filepath: str, pixel_size: int) -> float:  #
         img_area = width * pixel_size * height * pixel_size
         img_area /= 1e6  # convert to square kilometers
     return img_area
+
+
+def calculate_raster_area(filepath: str, pixel_size: Optional[float] = None) -> float:
+    """
+    Calculate the ground area a GeoTIFF covers, in square kilometers.
+
+    The pixel size is read from the raster's own geotransform, so no per-satellite table
+    can go stale. ``pixel_size`` is only a fallback for a raster without a geotransform.
+
+    Args:
+        filepath (str): Path to the GeoTIFF.
+        pixel_size (Optional[float]): Metres per pixel to assume when the raster carries
+            no geotransform.
+
+    Returns:
+        float: Area in square kilometers, or 0.0 when the raster cannot be read.
+    """
+    from osgeo import gdal
+
+    gdal.UseExceptions()
+    try:
+        dataset = gdal.Open(filepath, gdal.GA_ReadOnly)
+    except Exception as e:
+        logger.warning(f"Could not open raster {filepath}: {e}")
+        return 0.0
+    if dataset is None:
+        logger.warning(f"Could not open raster {filepath}")
+        return 0.0
+
+    try:
+        width, height = dataset.RasterXSize, dataset.RasterYSize
+        geotransform = dataset.GetGeoTransform()
+        if geotransform:
+            x_size, y_size = abs(geotransform[1]), abs(geotransform[5])
+        else:
+            x_size = y_size = float(pixel_size or 0)
+        if not x_size or not y_size:
+            logger.warning(f"No pixel size available for {filepath}")
+            return 0.0
+        return (width * x_size) * (height * y_size) / 1e6
+    finally:
+        dataset = None
+
+
+def find_source_raster(jpg_filename: str, roi_directory: str) -> Optional[str]:
+    """
+    Locate the GeoTIFF a preprocessed RGB preview was made from.
+
+    The preview is only a proxy for the scene's footprint, and for Sentinel-1 it is not
+    even that  coastsat renders it as a titled matplotlib figure whose dimensions are
+    figsize times dpi, unrelated to the raster. The GeoTIFF is the authority.
+
+    Args:
+        jpg_filename (str): Preview filename, e.g. ``2023-05-06-02-07-48_RGB_S1.jpg``.
+        roi_directory (str): The ROI's data directory, which holds the per-satellite
+            folders (``S1/VV``, ``S2/ms``, ...).
+
+    Returns:
+        Optional[str]: Path to the matching GeoTIFF, or None when none is found.
+    """
+    if not roi_directory or not os.path.isdir(roi_directory):
+        return None
+
+    basename = os.path.basename(jpg_filename)
+    satname = get_satellite_name(basename)
+    if not satname:
+        return None
+    date = basename[:19]
+
+    if satname == "S1":
+        # one folder per polarization; any of them describes the scene's footprint
+        subdirectories = [os.path.join("S1", polar) for polar in SAR_POLARIZATIONS]
+    else:
+        subdirectories = [os.path.join(satname, "ms")]
+
+    for subdirectory in subdirectories:
+        matches = sorted(
+            glob.glob(os.path.join(roi_directory, subdirectory, f"{date}*.tif"))
+        )
+        if matches:
+            return matches[0]
+    return None
 
 
 def validate_geometry_types(
@@ -3655,6 +3868,9 @@ def create_roi_settings(
     sat_list = settings["sat_list"]
     landsat_collection = settings.get("landsat_collection", "C02")
     dates = settings["dates"]
+    sentinel_1_properties = settings.get("sentinel_1_properties") or (
+        get_default_sentinel_1_properties()
+    )
     for roi in selected_rois["features"]:
         roi_id = str(roi["properties"]["id"])
         sitename = (
@@ -3670,10 +3886,8 @@ def create_roi_settings(
             "sitename": sitename,
             "filepath": filepath,
             "include_T2": False,
-            "sentinel_1_properties": {
-                "transmitterReceiverPolarisation": ["VH"],
-                "instrumentMode": "IW",
-            },  # default sentinel 1 properties
+            # deepcopy so the ROIs do not share one mutable dict
+            "sentinel_1_properties": copy.deepcopy(sentinel_1_properties),
         }
         roi_settings[roi_id] = inputs_dict
     return roi_settings

--- a/src/coastseg/extracted_shoreline.py
+++ b/src/coastseg/extracted_shoreline.py
@@ -1,4 +1,5 @@
 # Standard library imports
+import ast
 import copy
 import datetime
 import fnmatch
@@ -22,7 +23,13 @@ import pytz
 from ipyleaflet import GeoJSON
 
 matplotlib.use("Agg")  # Use a non-GUI backend
-from coastsat import SDS_preprocess, SDS_shoreline, SDS_tools, SDS_transects
+from coastsat import (
+    SDS_download,
+    SDS_preprocess,
+    SDS_shoreline,
+    SDS_tools,
+    SDS_transects,
+)
 from osgeo import gdal
 from shapely.geometry import LineString, MultiPoint
 from skimage import measure, morphology
@@ -36,6 +43,7 @@ from coastseg import (
     file_utilities,
     geodata_processing,
     plotting,
+    sar_model,
 )
 from coastseg.intersections import split_line
 from coastseg.model_info import ModelInfo
@@ -53,6 +61,167 @@ NO_SEGMENTATIONS_PASSED_FILTER_MESSAGE = (
     "No segmentations passed the segmentation filter. No shorelines will be extracted."
 )
 NO_SEGMENTATIONS_FOUND_MESSAGE = "No segmentations found to extract shorelines from. No shorelines will be extracted."
+
+# How a shoreline was segmented, recorded per shoreline in output['segmentation_method'].
+# CoastSeg maps shorelines from class labels in a *_res.npz, never by thresholding MNDWI,
+# so none of these carry an MNDWI threshold -- see threshold_filter_applies() below.
+SEGMENTATION_ZOO_MODEL = "zoo_model"  # optical: Zoo classifier labels, no threshold
+# Sentinel-1 goes through the ONNX model in coastseg.sar_model, which has no Otsu
+# fallback: run_sar_segmentation raises rather than thresholding. Reuse coastsat's
+# constants so the two spell them the same way. SAR_OTSU only ever appears on output
+# from the coastsat extraction path, which does fall back.
+SEGMENTATION_SAR_MODEL = SDS_tools.SEGMENTATION_SAR_MODEL
+SEGMENTATION_SAR_OTSU = SDS_tools.SEGMENTATION_SAR_OTSU
+
+
+def get_segmentation_method(satname: str) -> str:
+    """Return how shorelines for ``satname`` were segmented.
+
+    Args:
+        satname (str): Satellite mission name ('L5', 'L7', 'L8', 'L9', 'S2', 'S1').
+
+    Returns:
+        str: One of ``SEGMENTATION_SAR_MODEL`` or ``SEGMENTATION_ZOO_MODEL``.
+    """
+    return SEGMENTATION_SAR_MODEL if satname == "S1" else SEGMENTATION_ZOO_MODEL
+
+
+def threshold_filter_applies(output: dict) -> np.ndarray:
+    """Per shoreline, whether ``settings['otsu_threshold']`` may be compared to its threshold.
+
+    CoastSat's ``output['MNDWI_threshold']`` holds a different quantity depending on how
+    the shoreline was mapped: an MNDWI value for the optical contour path, an Otsu
+    threshold in dB for SAR, or NaN when a segmentation model mapped it and there is no
+    threshold at all. Filtering the latter two against an MNDWI range silently deletes
+    them -- NaN fails every comparison and a dB value near -20 is outside any sensible
+    MNDWI range.
+
+    CoastSeg's own extraction records no ``MNDWI_threshold`` at all, so this returns
+    all-False for CoastSeg-produced output: there is nothing to compare. It mirrors
+    ``SDS_transects.threshold_filter_applies`` for output that does carry the column,
+    such as a session extracted by CoastSat itself.
+
+    Args:
+        output (dict): Merged extracted-shoreline dict.
+
+    Returns:
+        np.ndarray: Boolean, one entry per shoreline. False means "exempt this shoreline
+        from the threshold filter" rather than "discard it".
+    """
+    n_shorelines = len(output.get("shorelines", []))
+
+    if "MNDWI_threshold" not in output:
+        return np.zeros(n_shorelines, dtype=bool)
+
+    thresholds = np.array(output["MNDWI_threshold"], dtype=float)
+
+    if "segmentation_method" in output:
+        comparable = np.array(
+            [
+                method == SDS_tools.SEGMENTATION_MNDWI
+                for method in output["segmentation_method"]
+            ]
+        )
+    elif "satname" in output:
+        # older outputs: every SAR shoreline was thresholded in dB
+        comparable = np.array([satname != "S1" for satname in output["satname"]])
+    else:
+        comparable = np.ones(len(thresholds), dtype=bool)
+
+    # a NaN threshold can never satisfy a range, so it must not be filtered on
+    return comparable & np.isfinite(thresholds)
+
+
+def warn_if_sar_falls_back_to_otsu(settings: dict, metadata: dict) -> bool:
+    """Warn before extraction when no S1 scene will reach the SAR segmentation model.
+
+    coastsat is deliberately forgiving: ``load_sar_segmenter`` returns None instead of
+    raising when the model cannot be used -- onnxruntime missing, the ~130 MB download
+    unreachable offline, ``sar_model_path`` pointing at a file that is not there -- and
+    every scene is then thresholded with the legacy Otsu method. The run still produces
+    shorelines, just measurably different ones, and coastsat says so only in its own log
+    inside the session folder. Say it where the user is actually looking instead.
+
+    Loading here is not wasted work: coastsat caches the session per model path, so the
+    extraction that follows reuses it rather than re-reading the file.
+
+    Args:
+        settings (dict): Shoreline settings handed to ``SDS_shoreline.extract_shorelines``.
+        metadata (dict): Per-satellite metadata; S1 must be present for this to apply.
+
+    Returns:
+        bool: True when the warning fired, meaning the whole run falls back to Otsu.
+    """
+    if not metadata.get("S1"):
+        return False
+
+    method = str(
+        settings.get("sar_segmentation", SDS_shoreline.SAR_SEGMENTATION_DEFAULT)
+    ).lower()
+    if method == "otsu":
+        # the user asked for this, so it is not a problem worth a warning
+        logger.info(
+            "settings['sar_segmentation'] is 'otsu': Sentinel-1 scenes will be "
+            "thresholded rather than segmented with the SAR model."
+        )
+        return False
+
+    if SDS_shoreline.load_sar_segmenter(settings, logger=logger) is not None:
+        return False
+
+    message = (
+        "The Sentinel-1 segmentation model could not be loaded, so every S1 scene in "
+        "this run falls back to the legacy Otsu threshold. Shorelines will still be "
+        "produced, but they will differ from model-segmented ones. Common causes: "
+        "onnxruntime is not installed, the model could not be downloaded (no internet "
+        "on first use), or settings['sar_model_path'] points at a missing or invalid "
+        ".onnx file. Set settings['sar_segmentation'] = 'otsu' to silence this."
+    )
+    logger.warning(message)
+    print(f"WARNING: {message}")
+    return True
+
+
+def report_sar_segmentation_methods(output: dict) -> Dict[str, int]:
+    """Report how many S1 shorelines the model segmented and how many Otsu thresholded.
+
+    The pre-flight check in :func:`warn_if_sar_falls_back_to_otsu` cannot see a *per
+    scene* fallback -- coastsat also drops to Otsu for an individual scene it cannot
+    segment, such as a legacy single-polarization one -- so tally what actually happened
+    once the run is over. This is the honest record of how the shorelines were produced.
+
+    Args:
+        output (dict): Merged output from ``SDS_shoreline.extract_shorelines``.
+
+    Returns:
+        Dict[str, int]: Counts keyed by segmentation method, for SAR methods only.
+    """
+    methods = output.get("segmentation_method") or []
+    counts = {
+        SEGMENTATION_SAR_MODEL: 0,
+        SEGMENTATION_SAR_OTSU: 0,
+    }
+    for method in methods:
+        if method in counts:
+            counts[method] += 1
+
+    total = counts[SEGMENTATION_SAR_MODEL] + counts[SEGMENTATION_SAR_OTSU]
+    if total == 0:
+        return counts
+
+    thresholded = counts[SEGMENTATION_SAR_OTSU]
+    if thresholded:
+        message = (
+            f"{thresholded} of {total} Sentinel-1 shorelines were mapped with the "
+            f"legacy Otsu threshold instead of the SAR segmentation model."
+        )
+        logger.warning(message)
+        print(f"WARNING: {message}")
+    else:
+        logger.info(
+            f"All {total} Sentinel-1 shorelines were mapped with the SAR segmentation model."
+        )
+    return counts
 
 
 class SegmentationFilter:
@@ -250,9 +419,19 @@ def get_filepath(filepath_data: str, sitename: str, satname: str) -> List[str]:
         fp_mask = os.path.join(filepath_data, sitename, satname, "mask")
         filepath = [fp_ms, fp_swir, fp_mask]
     elif satname == "S1":
-        # access downloaded Sentinel 1 images
-        fp_vh = os.path.join(filepath_data, sitename, satname, "VH")
-        filepath = [fp_vh]
+        # access downloaded Sentinel 1 images: one folder per polarization, in
+        # canonical order, and only the ones that actually exist. Mirrors
+        # SDS_tools.get_filepath so a VV+VH site is readable and a legacy VH-only
+        # site keeps working.
+        s1_root = os.path.join(filepath_data, sitename, satname)
+        filepath = [
+            os.path.join(s1_root, polarization)
+            for polarization in SDS_tools.SAR_POLARIZATIONS
+            if os.path.isdir(os.path.join(s1_root, polarization))
+        ]
+        if not filepath:
+            # nothing downloaded yet: keep the legacy shape so callers fail the same way
+            filepath = [os.path.join(s1_root, "VH")]
 
     return filepath
 
@@ -450,6 +629,12 @@ def read_metadata_file(filepath: str) -> Dict[str, Union[str, int, float]]:
         "im_quality",
         "im_width",
         "im_height",
+        # Sentinel-1 only: the polarizations downloaded for this scene, in the order
+        # they are stacked. Written by coastsat as a repr'd list, e.g. "['VV', 'VH']".
+        # saved_polarization is the pre-multi-polarization spelling, still read so
+        # legacy VH-only sites resolve to ["VH"] instead of [].
+        "band_order",
+        "saved_polarization",
     ]
 
     # Mapping of actual file keys to metadata keys
@@ -463,6 +648,8 @@ def read_metadata_file(filepath: str) -> Dict[str, Union[str, int, float]]:
         "im_quality": -1,
         "im_width": -1,
         "im_height": -1,
+        "band_order": [],
+        "saved_polarization": "",
     }
 
     with open(filepath, "r") as f:
@@ -501,11 +688,42 @@ def read_metadata_file(filepath: str) -> Dict[str, Union[str, int, float]]:
                     value = float(value)
                 except ValueError:
                     pass  # Keep the value as a string if conversion to float fails
+            elif key == "band_order":
+                # Written as a repr'd list. A malformed value must not take down the
+                # whole read: band_order is optional and absent from legacy files.
+                try:
+                    parsed = ast.literal_eval(value)
+                except (ValueError, SyntaxError):
+                    logger.warning(
+                        f"Could not parse band_order {value!r} in {filepath}; "
+                        "treating it as unknown."
+                    )
+                    parsed = []
+                if isinstance(parsed, str):
+                    parsed = [parsed]
+                value = [str(band) for band in parsed] if parsed else []
 
             # Update the metadata dictionary with the extracted key-value pair.
             metadata[key] = value
 
     return metadata
+
+
+def get_band_order_from_meta(meta_info: Dict[str, Union[str, int, float]]) -> List[str]:
+    """Return the Sentinel-1 polarizations a scene's metadata file recorded.
+
+    Delegates to coastsat's resolver so the two cannot drift.
+
+    Args:
+        meta_info (Dict[str, Union[str, int, float]]): Parsed contents of a metadata
+            .txt file, as returned by :func:`read_metadata_file`.
+
+    Returns:
+        List[str]: Polarizations in the order they are stacked, or ``[]`` when the file
+        recorded none. Files written before multi-polarization support carry only
+        ``saved_polarization``, which resolves to a single-entry list.
+    """
+    return list(SDS_download.get_band_order_from_meta(meta_info))
 
 
 def format_date(date_str: Union[str, datetime.datetime]) -> datetime.datetime:
@@ -588,6 +806,11 @@ def get_metadata(inputs: dict, data_folder_location: str = "") -> dict:
                 "im_quality": [],
                 "im_dimensions": [],
             }
+            if satname == "S1":
+                # Which polarizations each scene has. coastsat reads this when it cannot
+                # list the files on disk, e.g. to tell a complete scene from one still
+                # missing a band.
+                metadata[satname]["band_order"] = []
             # directory where the metadata .txt files are stored
             filepath_meta = os.path.join(sat_path, "meta")
             # get the list of filenames and sort it chronologically
@@ -617,6 +840,13 @@ def get_metadata(inputs: dict, data_folder_location: str = "") -> dict:
                     parse_date_from_filename(meta_info["filename"])  # type: ignore
                 )
                 metadata[satname]["im_quality"].append(meta_info["im_quality"])
+                if satname == "S1":
+                    # appended unconditionally so band_order stays the same length as
+                    # filenames and band_order[i] is index-safe, including on sites
+                    # mixing new dual-pol scenes with legacy VH-only ones
+                    metadata[satname]["band_order"].append(
+                        get_band_order_from_meta(meta_info)
+                    )
                 # if the metadata file didn't contain im_height or im_width set this as an empty list
                 if meta_info["im_height"] == -1 or meta_info["im_height"] == -1:
                     metadata[satname]["im_dimensions"].append([])
@@ -1168,6 +1398,7 @@ def combine_satellite_data(satellite_data: dict) -> dict:
         "shorelines": [],
         "idx": [],
         "satname": [],
+        "segmentation_method": [],
     }
 
     # Iterate through satellite_data keys (satellite names)
@@ -1281,6 +1512,10 @@ def process_satellite(
     output[satname].setdefault("cloud_cover", [])
     output[satname].setdefault("filename", [])
     output[satname].setdefault("idx", [])
+    # Recorded for every satellite, not just S1: merge_satellite_data builds its column
+    # list from the keys present, so a column missing on one satellite desynchronizes the
+    # merged lists against 'satname'.
+    output[satname].setdefault("segmentation_method", [])
 
     if len(filenames) == 0:
         logger.warning(f"Satellite {satname} had no imagery")
@@ -1372,6 +1607,9 @@ def process_satellite(
             output[satname].setdefault("cloud_cover", []).append(result["cloud_cover"])
             output[satname].setdefault("filename", []).append(filenames[index])
             output[satname].setdefault("idx", []).append(index)
+            output[satname].setdefault("segmentation_method", []).append(
+                get_segmentation_method(satname)
+            )
 
     pbar.close()
     return output
@@ -1473,6 +1711,16 @@ def process_satellite_image(
     im_ms, georef, cloud_mask, im_nodata = SDS_preprocess.preprocess_image(
         fn, satname, settings=settings, collection=collection
     )
+
+    # Sentinel-1 scenes are swath crops, so a large share of a downloaded tile is often
+    # empty. preprocess_image reports an all-zero nodata mask for S1, which lets those
+    # blank areas reach the contour finder and be traced as shoreline. Recover the real
+    # mask from the GeoTIFFs before any of the checks below run.
+    if satname == "S1" and settings.get("sar_mask_nodata", True):
+        sar_nodata = sar_model.sar_nodata_mask(fn)
+        if sar_nodata is not None and sar_nodata.shape == im_nodata.shape:
+            im_nodata = np.logical_or(im_nodata, sar_nodata)
+            cloud_mask = np.logical_or(cloud_mask, sar_nodata)
 
     # if percentage of no data pixels are greater than allowed, skip
     percent_no_data_allowed = settings.get("percent_no_data", 1.0)
@@ -2003,7 +2251,11 @@ class Extracted_Shoreline:
         # Use roi id to identify which ROI extracted shorelines derive from
         self.roi_id = ""
         # dictionary : dictionary of extracted shorelines
-        # contains keys 'dates', 'shorelines', 'filename', 'cloud_cover', 'geoaccuracy', 'idx', 'MNDWI_threshold', 'satname'
+        # contains keys 'dates', 'shorelines', 'filename', 'cloud_cover', 'geoaccuracy',
+        # 'idx', 'satname', 'segmentation_method'.
+        # Note there is no 'MNDWI_threshold': CoastSeg maps shorelines from class labels
+        # in a *_res.npz, never by thresholding MNDWI, so there is no threshold to record.
+        # Anything filtering on that column must go through threshold_filter_applies().
         self.dictionary = {}
         # shoreline_settings: dictionary of settings used to extract shoreline
         self.shoreline_settings = {}
@@ -2538,6 +2790,10 @@ class Extracted_Shoreline:
                     f"edit_metadata metadata['{satname}'] length {len(metadata[satname].get('im_quality', []))} of im_quality: {np.unique(metadata[satname].get('im_quality', []))}"
                 )
 
+        # coastsat drops to Otsu without raising when the SAR model is unusable, so say
+        # so before the run rather than letting it degrade silently
+        warn_if_sar_falls_back_to_otsu(self.shoreline_settings, metadata)
+
         # extract shorelines with coastsat's models
         extracted_shorelines = SDS_shoreline.extract_shorelines(
             metadata,
@@ -2545,6 +2801,8 @@ class Extracted_Shoreline:
             output_directory=output_directory,
             shoreline_extraction_area=shoreline_extraction_area,
         )
+        # catches the per-scene fallbacks the pre-flight check cannot predict
+        report_sar_segmentation_methods(extracted_shorelines)
         logger.info(f"extracted_shoreline_dict: {extracted_shorelines}")
         # postprocessing by removing duplicates and removing in inaccurate georeferencing (set threshold to 10 m)
         extracted_shorelines = SDS_tools.remove_duplicates(
@@ -2629,8 +2887,30 @@ class Extracted_Shoreline:
             "percent_no_data",
             "model_session_path",  # path to model session file
             "apply_cloud_mask",
+            # Sentinel-1 only. coastsat reads these straight out of this dict:
+            # sar_segmentation and sar_model_path in SDS_shoreline.load_sar_segmenter,
+            # sar_water_threshold in SDS_shoreline.segment_sar_water. Leaving them out
+            # of this allowlist silently drops them and the user's choice is ignored.
+            "sar_segmentation",
+            "sar_water_threshold",
+            "sar_model_path",
         ]
         shoreline_settings = {k: v for k, v in settings.items() if k in SHORELINE_KEYS}
+
+        # Stored relative to the CoastSeg directory so config.json stays portable, but
+        # coastsat has to be handed something it can open.
+        #
+        # When the user set no path, point coastsat at a model sitting in CoastSeg's own
+        # models/ directory if there is one. coastsat looks only in its pooch cache, so
+        # without this a manually downloaded model would be used by the zoo workflow and
+        # silently re-downloaded (~130 MB) by this one. Still "" when nothing is there,
+        # which lets coastsat resolve and download as usual.
+        if "sar_model_path" in shoreline_settings:
+            shoreline_settings["sar_model_path"] = (
+                common.resolve_sar_model_path(shoreline_settings["sar_model_path"])
+                or sar_model.find_local_sar_model()
+            )
+
         shoreline_settings.update(
             {
                 "reference_shoreline": reference_shoreline,

--- a/src/coastseg/map_UI.py
+++ b/src/coastseg/map_UI.py
@@ -180,6 +180,29 @@ class UI:
             style={"description_width": "initial"},
         )
 
+        # create dropdown to select how Sentinel-1 land/water is segmented
+        sar_segmentation_dropdown = widgets.Dropdown(
+            options=[
+                ("Segmentation model (recommended)", "model"),
+                ("Otsu threshold", "otsu"),
+            ],
+            value="model",
+            description="sar_segmentation :",
+            disabled=False,
+            style={"description_width": "initial"},
+        )
+
+        # create slider to select the P(water) cutoff used by the SAR model
+        sar_water_threshold_slider = widgets.FloatSlider(
+            description="SAR Water Threshold",
+            value=0.5,
+            min=0.05,
+            max=0.95,
+            step=0.05,
+            readout_format=".2f",
+            style={"description_width": "initial"},
+        )
+
         # create toggle to select cloud mask issue
         cloud_mask_issue = widgets.ToggleButtons(
             options=["False", "True"],
@@ -228,6 +251,27 @@ class UI:
             "cloud_mask_issue",
             "Cloud Mask Issue",
             "Switch to True if sand pixels are masked (in black) on many images",
+            advanced=True,
+            index=-1,
+        )
+
+        settings_dashboard.add_custom_widget(
+            sar_segmentation_dropdown,
+            "sar_segmentation",
+            "SAR Segmentation Method",
+            "Sentinel-1 only. 'Segmentation model' runs the trained land/water model. "
+            "'Otsu threshold' reverts to thresholding the imagery, which is what CoastSeg "
+            "did before the model existed.",
+            advanced=True,
+            index=-1,
+        )
+        settings_dashboard.add_custom_widget(
+            sar_water_threshold_slider,
+            "sar_water_threshold",
+            "SAR Water Threshold",
+            "Sentinel-1 only, and only when the segmentation model is used. A pixel is "
+            "water when the model's probability reaches this value. Raise it for higher "
+            "precision on water, lower it to catch more.",
             advanced=True,
             index=-1,
         )

--- a/src/coastseg/models_UI.py
+++ b/src/coastseg/models_UI.py
@@ -2,6 +2,7 @@ import contextlib
 import io
 import logging
 import os
+from pathlib import Path
 from typing import Optional
 
 from ipyfilechooser import FileChooser
@@ -24,6 +25,7 @@ from coastseg import (
     common,
     core_utilities,
     file_utilities,
+    sar_model,
     settings_UI,
     zoo_model,
 )
@@ -89,6 +91,10 @@ class UI_Models:
         self.NDWI_models = [
             "global_segformer_NDWI_4class_14172182",  # global segformer model
             "AK_segformer_NDWI_4class_14183210",  # AK segformer model
+        ]
+
+        self.SAR_models = [
+            sar_model.DEFAULT_SAR_MODEL_DIRNAME,
         ]
         self.session_name = ""
         self.shoreline_session_directory = ""
@@ -557,6 +563,7 @@ class UI_Models:
                 "RGB",
                 "MNDWI",
                 "NDWI",
+                "SAR",
             ],
             value="RGB",
             description="Model Input:",
@@ -797,8 +804,19 @@ class UI_Models:
             self.model_dropdown.options = self.MNDWI_models
         if change["new"] == "NDWI":
             self.model_dropdown.options = self.NDWI_models
+        if change["new"] == "SAR":
+            self.model_dropdown.options = self.SAR_models
 
         self.model_dict["img_type"] = change["new"]
+
+        if change["new"] == "SAR":
+            self.model_dict["local_model_path"] = str(
+                Path(core_utilities.get_base_dir())
+                / "models"
+                / sar_model.DEFAULT_SAR_MODEL_DIRNAME
+            )
+        else:
+            self.model_dict["local_model_path"] = ""
 
     @model_download_view.capture(clear_output=True)
     def download_model_button_clicked(self, button: Button) -> None:
@@ -811,6 +829,18 @@ class UI_Models:
                 "Select a model before downloading.",
                 position=1,
             )
+            return
+
+        if str(self.model_dict.get("img_type", "")).upper() == "SAR":
+            # The SAR model is not shipped with CoastSeg: it is fetched from Hugging Face
+            # on first use and cached, so this button is a no-op once it is on disk.
+            local_model_path = self.model_dict.get("local_model_path", "")
+            try:
+                onnx_path = sar_model.find_sar_onnx_file(local_model_path)
+            except (sar_model.SarModelError, FileNotFoundError) as error:
+                self.launch_error_box("Download Failed", str(error))
+                return
+            print(f"The SAR model is ready.\nIt will be read from: {onnx_path}")
             return
 
         button.disabled = True

--- a/src/coastseg/sar_model.py
+++ b/src/coastseg/sar_model.py
@@ -1,0 +1,1224 @@
+"""Sentinel-1 SAR land/water segmentation with an exported ONNX model.
+
+The model takes three real SAR channels -- ``VV``, ``VH`` and ``VV-VH``, all in dB --
+and returns a per-pixel water probability. Every preprocessing constant
+(channel order, normalization statistics, output stride, nodata code, class names) is
+read from the ``.onnx`` file's own ``metadata_props`` at load time, so swapping in a
+retrained model cannot silently desynchronize the constants.
+
+This runs in-process in the main CoastSeg environment: ``onnxruntime`` and ``gdal`` are
+both already dependencies here, and neither exists in the ``segmentation_workflow``
+TensorFlow subprocess environment.
+
+The batch driver writes the same artifacts the TensorFlow zoo path writes
+(``*_predseg.png``, ``*_res.npz``, ``model_settings.json``, ``model_info.json``,
+``segmentation_summary.json``) so the existing npz-driven shoreline extraction consumes
+SAR output with no changes.
+"""
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+import onnxruntime as ort
+from osgeo import gdal, osr
+from PIL import Image
+
+from coastsat import SDS_sar_model, SDS_tools
+
+from coastseg import core_utilities
+
+gdal.UseExceptions()
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_SAR_MODEL_DIRNAME",
+    "SarModelError",
+    "MissingPolarizationError",
+    "UnsupportedSpeckleFilterError",
+    "SarModelSpec",
+    "SarPrediction",
+    "describe_sar_polarization_remedy",
+    "find_sar_onnx_file",
+    "find_local_sar_model",
+    "is_sar_model_directory",
+    "load_sar_model_spec",
+    "segment_scene",
+    "sar_nodata_mask",
+    "run_sar_segmentation",
+]
+
+# Directory under <CoastSeg>/models where a user drops a model by hand. Nothing ships
+# there: the default model is downloaded on first use (see find_sar_onnx_file), so this
+# directory is routinely absent or empty.
+DEFAULT_SAR_MODEL_DIRNAME = "SAR_segmentation_model"
+
+# Speckle filters this module knows how to apply. The model records which filter its
+# training data used; anything other than "none" would have to be implemented at step 5
+# of the preprocessing pipeline before this module can honour it.
+SUPPORTED_SPECKLE_FILTERS = frozenset({"none", ""})
+
+# Guard against accidentally feeding a whole-country mosaic to a fully convolutional
+# model. A 3000x3000 scene peaks around 220 MB, so this leaves generous headroom while
+# still failing with a readable message instead of an OOM kill.
+MAX_INPUT_PIXELS = 80_000_000
+
+# Same palette the TensorFlow zoo path uses, so the good/bad segmentation classifier
+# sees the colours it was trained on.
+CLASS_LABEL_COLORMAP = (
+    "#3366CC", "#DC3912", "#FF9900", "#109618", "#990099",
+    "#0099C6", "#DD4477", "#66AA00", "#B82E2E", "#316395",
+    "#ffe4e1", "#ff7373", "#666666", "#c0c0c0", "#66cdaa",
+    "#afeeee", "#0e2f44", "#420420", "#794044", "#3399ff",
+)
+
+_POLARIZATION_TOKEN_RE = re.compile(
+    r"_(%s)(?=(?:_dup\d+)?\.tif$)" % "|".join(SDS_tools.SAR_POLARIZATIONS),
+    re.IGNORECASE,
+)
+_DUP_TOKEN_RE = re.compile(r"_(dup\d+)\.tif$", re.IGNORECASE)
+
+# Cache sessions by (onnx path, providers) so a batch run loads the model once.
+_SESSION_CACHE: Dict[Tuple[str, Tuple[str, ...]], "ort.InferenceSession"] = {}
+
+
+class SarModelError(RuntimeError):
+    """Base class for every failure raised by the SAR segmentation path."""
+
+
+class MissingPolarizationError(SarModelError):
+    """Raised when a scene or a site lacks a polarization the model requires."""
+
+
+class UnsupportedSpeckleFilterError(SarModelError):
+    """Raised when the model was trained with a speckle filter this module cannot apply."""
+
+
+def describe_sar_polarization_remedy() -> str:
+    """Return the advice to give a user whose site is missing a requested polarization.
+
+    coastsat treats an S1 date as downloaded only when *every* requested polarization is
+    present, so re-running the download fetches the missing band and overwrites the
+    existing scene in place rather than skipping it as already downloaded. Route any new
+    message about missing polarizations through this rather than restating it.
+    """
+    return (
+        "Re-run the download for this site with the polarizations you want; the "
+        "missing ones will be fetched and the existing scenes overwritten in place."
+    )
+
+
+# ---------------------------------------------------------------------------
+# coastsat interop
+# ---------------------------------------------------------------------------
+
+
+def get_sar_polarizations() -> Tuple[str, ...]:
+    """Return the canonical polarization order, as coastsat defines it."""
+    return tuple(SDS_tools.SAR_POLARIZATIONS)
+
+
+def get_polarization_from_filename(filename: str) -> Optional[str]:
+    """Return the polarization token in ``filename``, or None when there isn't one.
+
+    Delegates to coastsat's implementation so the two cannot drift.
+
+    Args:
+        filename (str): A Sentinel-1 GeoTIFF path or basename.
+
+    Returns:
+        Optional[str]: ``"VV"``, ``"VH"``, ``"HH"``, ``"HV"`` or None.
+    """
+    return SDS_tools.get_polarization_from_filename(filename)
+
+
+# ---------------------------------------------------------------------------
+# Model spec
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SarModelSpec:
+    """Everything needed to preprocess for, run, and postprocess this ONNX model.
+
+    Every field is read from the ``.onnx`` file's ``metadata_props``; nothing here is
+    hardcoded against a particular checkpoint.
+    """
+
+    onnx_path: str
+    input_name: str
+    prob_output: str
+    channel_order: Tuple[str, ...]
+    mean: np.ndarray
+    std: np.ndarray
+    output_stride: int
+    nodata: int
+    classes: Dict[int, str]
+    input_scale: str = "dB"
+    speckle_filter: Dict[str, Any] = field(default_factory=lambda: {"type": "none"})
+    water_threshold: float = 0.5
+
+    @property
+    def water_class_indices(self) -> List[int]:
+        """Class indices whose label names mean water."""
+        water_names = {"water", "whitewater"}
+        return sorted(
+            index
+            for index, name in self.classes.items()
+            if str(name).strip().lower() in water_names
+        )
+
+    @property
+    def required_polarizations(self) -> Tuple[str, ...]:
+        """Polarizations that must be on disk to build every model channel.
+
+        Derived from ``channel_order``, so a difference channel such as ``VV-VH``
+        contributes both of its operands.
+        """
+        polarizations: List[str] = []
+        for channel in self.channel_order:
+            for token in str(channel).upper().split("-"):
+                token = token.strip()
+                if token and token not in polarizations:
+                    polarizations.append(token)
+        canonical = get_sar_polarizations()
+        ordered = [p for p in canonical if p in polarizations]
+        ordered += [p for p in polarizations if p not in ordered]
+        return tuple(ordered)
+
+
+def find_sar_onnx_file(model_directory: str, download: bool = True) -> str:
+    """Return the ``.onnx`` file to run, fetching the default model if there isn't one.
+
+    The model is not shipped with CoastSeg -- it is ~130 MB, and ``models/**/*.onnx`` is
+    gitignored, so a fresh clone has none. It is downloaded from Hugging Face on first
+    use instead.
+
+    A copy inside ``model_directory`` always wins, so a custom or retrained model, and
+    an offline machine that already has one, keep working untouched. Otherwise this
+    defers to ``coastsat.SDS_sar_model``, which pins the download by sha256 and caches
+    it via pooch. Reusing coastsat's cache rather than downloading into
+    ``model_directory`` is deliberate: both SAR workflows then share one ~130 MB copy
+    instead of keeping one each.
+
+    Args:
+        model_directory (str): Directory that may hold an exported model.
+        download (bool): Fetch the default model when the directory holds none.
+
+    Returns:
+        str: Absolute path to the ``.onnx`` file.
+
+    Raises:
+        FileNotFoundError: If there is no local model and ``download`` is False.
+        SarModelError: If the default model is needed but cannot be obtained.
+    """
+    directory = Path(model_directory).expanduser() if model_directory else None
+
+    if directory is not None and directory.is_dir():
+        candidates = sorted(directory.glob("*.onnx"))
+        if len(candidates) > 1:
+            logger.warning(
+                "Multiple .onnx files in %s; using %s", directory, candidates[0].name
+            )
+        if candidates:
+            return str(candidates[0].resolve())
+
+    if not download:
+        raise FileNotFoundError(
+            f"No .onnx file found in the SAR model directory: {directory}"
+        )
+
+    # already downloaded by either workflow on a previous run
+    cached = SDS_sar_model.get_sar_model_path()
+    if os.path.isfile(cached):
+        return os.path.abspath(cached)
+
+    logger.info(
+        "No SAR model in %s; downloading the default model from Hugging Face.", directory
+    )
+    print(
+        "The Sentinel-1 segmentation model (~130 MB) is not on this machine yet and is "
+        "being downloaded. This happens once."
+    )
+    try:
+        return SDS_sar_model.fetch_default_sar_model()
+    except SDS_sar_model.SarModelUnavailable as error:
+        raise SarModelError(
+            f"The Sentinel-1 segmentation model was not found in {directory} and could "
+            f"not be downloaded: {error}. Download "
+            f"{SDS_sar_model.SAR_MODEL_CONFIG['model_name']} manually from "
+            f"{SDS_sar_model.SAR_MODEL_CONFIG['url'].split('?')[0]} and place it in "
+            f"models/{DEFAULT_SAR_MODEL_DIRNAME}."
+        ) from error
+
+
+def get_sar_model_directory() -> str:
+    """Return CoastSeg's designated SAR model directory.
+
+    This is the one place a user can drop a manually downloaded model and have *both*
+    SAR workflows pick it up: the zoo path reads it directly, and the coastsat path is
+    pointed at it by :func:`find_local_sar_model`.
+    """
+    return str(
+        Path(core_utilities.get_base_dir()) / "models" / DEFAULT_SAR_MODEL_DIRNAME
+    )
+
+
+def find_local_sar_model() -> str:
+    """Return a model already sitting in CoastSeg's model directory, or ``""``.
+
+    Never downloads and never raises -- ``""`` simply means "nothing placed by hand",
+    which leaves the caller free to fall back to coastsat's own resolution.
+
+    Returns:
+        str: Absolute path to the ``.onnx``, or ``""`` when there is none.
+    """
+    try:
+        return find_sar_onnx_file(get_sar_model_directory(), download=False)
+    except FileNotFoundError:
+        return ""
+
+
+def is_sar_model_directory(model_directory: Optional[str]) -> bool:
+    """Return True when ``model_directory`` is CoastSeg's ONNX SAR model directory.
+
+    True either because it already holds an ``.onnx``, or because it *is* the designated
+    SAR model directory, which may legitimately be empty or absent: the model is
+    downloaded on first use (see :func:`find_sar_onnx_file`). This routes the run, so it
+    has to give the same answer before and after that download -- otherwise the first
+    SAR run on a fresh clone would be sent down the TensorFlow path.
+    """
+    if not model_directory:
+        return False
+    try:
+        directory = Path(model_directory).expanduser()
+    except (OSError, ValueError):
+        return False
+    if directory.name == DEFAULT_SAR_MODEL_DIRNAME:
+        return True
+    return directory.is_dir() and any(directory.glob("*.onnx"))
+
+
+def _resolve_providers(use_gpu: bool) -> Tuple[str, ...]:
+    """Return the onnxruntime execution providers to try, CPU last."""
+    if not use_gpu:
+        return ("CPUExecutionProvider",)
+    available = set(ort.get_available_providers())
+    if "CUDAExecutionProvider" in available:
+        return ("CUDAExecutionProvider", "CPUExecutionProvider")
+    logger.info("CUDAExecutionProvider is unavailable; running SAR inference on CPU.")
+    return ("CPUExecutionProvider",)
+
+
+def _make_session(onnx_path: str, providers: Tuple[str, ...]) -> "ort.InferenceSession":
+    """Create (and cache) an inference session for ``onnx_path``."""
+    key = (onnx_path, providers)
+    session = _SESSION_CACHE.get(key)
+    if session is not None:
+        return session
+    try:
+        session = ort.InferenceSession(onnx_path, providers=list(providers))
+    except Exception as error:
+        if providers != ("CPUExecutionProvider",):
+            logger.warning(
+                "Failed to start onnxruntime with %s (%s); falling back to CPU.",
+                providers,
+                error,
+            )
+            return _make_session(onnx_path, ("CPUExecutionProvider",))
+        raise SarModelError(
+            f"Could not load the SAR ONNX model at {onnx_path}: {error}"
+        ) from error
+    _SESSION_CACHE[key] = session
+    return session
+
+
+def _json_metadata(metadata: Mapping[str, str], key: str, default: Any) -> Any:
+    """Read a JSON-encoded metadata value, falling back to ``default``."""
+    raw = metadata.get(key)
+    if raw is None:
+        return default
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        logger.warning("Could not parse ONNX metadata %r=%r; using default.", key, raw)
+        return default
+
+
+def _resolve_prob_output(
+    output_names: Sequence[str], graph_outputs: Sequence[str], onnx_path: str
+) -> str:
+    """Return the name of the graph output holding ``P(water)``.
+
+    Picking the wrong output does not fail: logits are real numbers too, so thresholding
+    them at 0.5 yields a plausible but wrong shoreline. The exported model carries both a
+    ``logits`` and a ``water_prob`` output, so guess only when there is nothing to guess
+    between.
+
+    Args:
+        output_names (Sequence[str]): Output names the model declares in its metadata,
+            or the graph's own names when it declares none.
+        graph_outputs (Sequence[str]): Output names the ONNX graph actually exposes.
+        onnx_path (str): Model path, for error messages.
+
+    Returns:
+        str: The output name to request from ``session.run``.
+
+    Raises:
+        SarModelError: If the probability output is ambiguous, or if the declared name
+            is not one the graph exposes.
+    """
+    names = [str(name) for name in output_names]
+    model_name = os.path.basename(onnx_path)
+
+    if "water_prob" in names:
+        chosen = "water_prob"
+    elif len(names) == 1:
+        # Nothing to disambiguate. Say so rather than silently trusting the name.
+        chosen = names[0]
+        logger.warning(
+            "%s has no output named 'water_prob'; using its only output %r as the water "
+            "probability. Values are thresholded directly, so they must be in [0, 1].",
+            model_name,
+            chosen,
+        )
+    else:
+        raise SarModelError(
+            f"{model_name} exposes outputs {names} and none is named 'water_prob', so "
+            "which one holds P(water) cannot be determined. Re-export the model with "
+            "its probability output named 'water_prob'."
+        )
+
+    if graph_outputs and chosen not in graph_outputs:
+        raise SarModelError(
+            f"{model_name} names {chosen!r} as its probability output, but its graph "
+            f"exposes {list(graph_outputs)}."
+        )
+    return chosen
+
+
+def load_sar_model_spec(model_directory: str, use_gpu: bool = False) -> SarModelSpec:
+    """Read the preprocessing contract out of the model's embedded metadata.
+
+    Args:
+        model_directory (str): Directory holding the exported ``.onnx`` model.
+        use_gpu (bool): Try the CUDA execution provider before CPU.
+
+    Returns:
+        SarModelSpec: The validated model contract.
+
+    Raises:
+        FileNotFoundError: If no ``.onnx`` file is present.
+        SarModelError: If the model does not carry a usable preprocessing contract.
+    """
+    onnx_path = find_sar_onnx_file(model_directory)
+    session = _make_session(onnx_path, _resolve_providers(use_gpu))
+    metadata = session.get_modelmeta().custom_metadata_map or {}
+
+    graph_outputs = [output.name for output in session.get_outputs()]
+    output_names = _json_metadata(metadata, "output_names", graph_outputs)
+    prob_output = _resolve_prob_output(output_names, graph_outputs, onnx_path)
+
+    graph_input = session.get_inputs()[0]
+    input_name = metadata.get("input_name") or graph_input.name
+
+    channel_order = tuple(
+        str(channel) for channel in _json_metadata(metadata, "channel_order", [])
+    )
+    if not channel_order:
+        raise SarModelError(
+            f"{onnx_path} does not declare 'channel_order' in its ONNX metadata, so "
+            "the band stack cannot be built safely. Re-export the model with metadata."
+        )
+
+    mean = np.asarray(_json_metadata(metadata, "normalization_mean", []), dtype=np.float32)
+    std = np.asarray(_json_metadata(metadata, "normalization_std", []), dtype=np.float32)
+    if mean.size != len(channel_order) or std.size != len(channel_order):
+        raise SarModelError(
+            f"{onnx_path}: normalization_mean/std have {mean.size}/{std.size} entries "
+            f"but channel_order has {len(channel_order)}."
+        )
+    if np.any(std == 0):
+        raise SarModelError(f"{onnx_path}: normalization_std contains a zero.")
+
+    # Cross-check against the graph itself so a metadata typo cannot go unnoticed.
+    graph_channels = graph_input.shape[1] if len(graph_input.shape) == 4 else None
+    if isinstance(graph_channels, int) and graph_channels != len(channel_order):
+        raise SarModelError(
+            f"{onnx_path}: the graph expects {graph_channels} channels but "
+            f"channel_order declares {len(channel_order)}."
+        )
+
+    raw_classes = _json_metadata(metadata, "classes", {"0": "land", "1": "water"})
+    classes = {int(index): str(name) for index, name in dict(raw_classes).items()}
+
+    speckle_filter = _json_metadata(metadata, "speckle_filter", {"type": "none"})
+    if not isinstance(speckle_filter, dict):
+        speckle_filter = {"type": str(speckle_filter)}
+
+    spec = SarModelSpec(
+        onnx_path=onnx_path,
+        input_name=str(input_name),
+        prob_output=str(prob_output),
+        channel_order=channel_order,
+        mean=mean,
+        std=std,
+        output_stride=int(metadata.get("output_stride", 32)),
+        nodata=int(metadata.get("nodata", 255)),
+        classes=classes,
+        input_scale=str(metadata.get("input_scale", "dB")),
+        speckle_filter=speckle_filter,
+    )
+    _check_speckle_filter(spec)
+    if not spec.water_class_indices:
+        logger.warning(
+            "%s declares classes %s, none of which is named 'water'. Shoreline "
+            "extraction will not know which class is water.",
+            onnx_path,
+            spec.classes,
+        )
+    return spec
+
+
+def get_session(spec: SarModelSpec, use_gpu: bool = False) -> "ort.InferenceSession":
+    """Return the cached inference session for ``spec``."""
+    return _make_session(spec.onnx_path, _resolve_providers(use_gpu))
+
+
+def _check_speckle_filter(spec: SarModelSpec) -> None:
+    """Raise when the model needs a speckle filter this module does not implement."""
+    filter_type = str(spec.speckle_filter.get("type", "none")).strip().lower()
+    if filter_type not in SUPPORTED_SPECKLE_FILTERS:
+        raise UnsupportedSpeckleFilterError(
+            f"{spec.onnx_path} was trained with the {filter_type!r} speckle filter, "
+            "which coastseg.sar_model does not implement. Running without it would "
+            "silently degrade accuracy."
+        )
+
+
+# ---------------------------------------------------------------------------
+# GDAL raster IO
+# ---------------------------------------------------------------------------
+
+
+def read_band(path: str) -> Tuple[np.ndarray, np.ndarray, Tuple[float, ...], str]:
+    """Read band 1 and its validity mask on the raster's own grid.
+
+    Args:
+        path (str): GeoTIFF path.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray, Tuple[float, ...], str]: ``(values, valid,
+        geotransform, projection)`` where ``values`` is float32 ``[H, W]`` and ``valid``
+        is a boolean ``[H, W]`` mask.
+
+    Raises:
+        SarModelError: If the raster cannot be opened or read.
+    """
+    dataset = None
+    try:
+        dataset = gdal.Open(path, gdal.GA_ReadOnly)
+        if dataset is None:
+            raise SarModelError(f"Could not open raster: {path}")
+        band = dataset.GetRasterBand(1)
+        values = band.ReadAsArray().astype(np.float32)
+        # GetMaskBand folds in the band's nodata value; a raster with no nodata set
+        # reports GMF_ALL_VALID, so this degrades safely to "everything is valid".
+        mask = band.GetMaskBand().ReadAsArray()
+        valid = (mask > 0) & np.isfinite(values)
+        geotransform = tuple(dataset.GetGeoTransform())
+        projection = dataset.GetProjection()
+    except SarModelError:
+        raise
+    except Exception as error:
+        raise SarModelError(f"Failed to read {path}: {error}") from error
+    finally:
+        dataset = None
+    return values, valid, geotransform, projection
+
+
+def grids_match(
+    geotransform_a: Sequence[float],
+    projection_a: str,
+    shape_a: Tuple[int, int],
+    geotransform_b: Sequence[float],
+    projection_b: str,
+    shape_b: Tuple[int, int],
+    atol: float = 1e-6,
+) -> bool:
+    """Return True when two rasters sit on the same grid (size, transform and CRS)."""
+    if tuple(shape_a) != tuple(shape_b):
+        return False
+    if not np.allclose(np.asarray(geotransform_a), np.asarray(geotransform_b), atol=atol):
+        return False
+    if projection_a == projection_b:
+        return True
+    if not projection_a or not projection_b:
+        return False
+    try:
+        srs_a = osr.SpatialReference()
+        srs_a.ImportFromWkt(projection_a)
+        srs_b = osr.SpatialReference()
+        srs_b.ImportFromWkt(projection_b)
+        return bool(srs_a.IsSame(srs_b))
+    except Exception:  # pragma: no cover - malformed WKT
+        return False
+
+
+def _bounds_from_grid(
+    geotransform: Sequence[float], shape: Tuple[int, int]
+) -> Tuple[float, float, float, float]:
+    """Return ``(minx, miny, maxx, maxy)`` for a north-up grid."""
+    height, width = shape
+    origin_x, pixel_width, row_rotation, origin_y, column_rotation, pixel_height = (
+        geotransform
+    )
+    if row_rotation or column_rotation:
+        logger.warning(
+            "Reference grid is rotated (%s, %s); reprojection bounds are approximate.",
+            row_rotation,
+            column_rotation,
+        )
+    far_x = origin_x + width * pixel_width
+    far_y = origin_y + height * pixel_height
+    return (min(origin_x, far_x), min(origin_y, far_y), max(origin_x, far_x), max(origin_y, far_y))
+
+
+def _mem_dataset(
+    array: np.ndarray, geotransform: Sequence[float], projection: str, gdal_type: int
+):
+    """Wrap a numpy array in an in-memory GDAL dataset carrying ``geotransform``."""
+    height, width = array.shape
+    dataset = gdal.GetDriverByName("MEM").Create("", width, height, 1, gdal_type)
+    dataset.SetGeoTransform(tuple(geotransform))
+    if projection:
+        dataset.SetProjection(projection)
+    dataset.GetRasterBand(1).WriteArray(array)
+    return dataset
+
+
+def read_band_on_grid(
+    path: str,
+    reference_geotransform: Sequence[float],
+    reference_projection: str,
+    reference_shape: Tuple[int, int],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Read band 1 aligned onto a reference grid, reprojecting only if it differs.
+
+    VV and VH of one Sentinel-1 GRD acquisition are geocoded together and virtually
+    always share a grid, so the fast path is a plain read. When they do differ the data
+    is resampled bilinearly and the validity mask nearest-neighbour, matching the
+    training pipeline.
+
+    Args:
+        path (str): GeoTIFF to read.
+        reference_geotransform (Sequence[float]): Target geotransform.
+        reference_projection (str): Target projection WKT.
+        reference_shape (Tuple[int, int]): Target ``(height, width)``.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: ``(values, valid)`` on the reference grid.
+    """
+    values, valid, geotransform, projection = read_band(path)
+    if grids_match(
+        geotransform,
+        projection,
+        values.shape,
+        reference_geotransform,
+        reference_projection,
+        reference_shape,
+    ):
+        return values, valid
+
+    logger.warning(
+        "%s is not on the reference grid (%s vs %s); reprojecting onto it.",
+        path,
+        values.shape,
+        reference_shape,
+    )
+    height, width = reference_shape
+    bounds = _bounds_from_grid(reference_geotransform, reference_shape)
+    warp_options = dict(
+        format="MEM",
+        dstSRS=reference_projection or None,
+        outputBounds=bounds,
+        width=width,
+        height=height,
+    )
+
+    source_values = _mem_dataset(values, geotransform, projection, gdal.GDT_Float32)
+    warped_values = gdal.Warp(
+        "",
+        source_values,
+        resampleAlg=gdal.GRA_Bilinear,
+        dstNodata=float("nan"),
+        **warp_options,
+    )
+
+    source_mask = _mem_dataset(
+        valid.astype(np.uint8), geotransform, projection, gdal.GDT_Byte
+    )
+    warped_mask = gdal.Warp(
+        "",
+        source_mask,
+        resampleAlg=gdal.GRA_NearestNeighbour,
+        dstNodata=0,
+        **warp_options,
+    )
+
+    aligned_values = warped_values.GetRasterBand(1).ReadAsArray().astype(np.float32)
+    aligned_mask = warped_mask.GetRasterBand(1).ReadAsArray()
+    aligned_valid = (aligned_mask > 0) & np.isfinite(aligned_values)
+    return aligned_values, aligned_valid
+
+
+# ---------------------------------------------------------------------------
+# Preprocessing / inference / postprocessing
+# ---------------------------------------------------------------------------
+
+
+def resolve_scene_polarizations(
+    file_paths: Sequence[str], required: Sequence[str]
+) -> Dict[str, str]:
+    """Map each required polarization to its file path.
+
+    Args:
+        file_paths (Sequence[str]): Per-polarization GeoTIFF paths for one scene.
+        required (Sequence[str]): Polarizations the model needs.
+
+    Returns:
+        Dict[str, str]: ``{polarization: path}``.
+
+    Raises:
+        MissingPolarizationError: If any required polarization is absent.
+    """
+    paths = [file_paths] if isinstance(file_paths, str) else list(file_paths)
+    found: Dict[str, str] = {}
+    for path in paths:
+        polarization = get_polarization_from_filename(path)
+        if polarization:
+            found.setdefault(polarization.upper(), path)
+
+    missing = [polarization for polarization in required if polarization not in found]
+    if missing:
+        scene = os.path.basename(paths[0]) if paths else "<no files>"
+        raise MissingPolarizationError(
+            f"{scene}: the SAR model needs {list(required)} but only "
+            f"{sorted(found) or 'no polarizations'} were found on disk."
+        )
+    return {polarization: found[polarization] for polarization in required}
+
+
+def _derive_channel(name: str, bands: Mapping[str, np.ndarray]) -> np.ndarray:
+    """Return one model channel, computing ``A-B`` differences from raw bands."""
+    key = str(name).upper()
+    if key in bands:
+        return bands[key]
+    if "-" in key:
+        left, right = key.split("-", 1)
+        if left in bands and right in bands:
+            return bands[left] - bands[right]
+    raise SarModelError(
+        f"Cannot build channel {name!r} from the available bands {sorted(bands)}."
+    )
+
+
+def build_sar_stack(
+    file_paths: Sequence[str], spec: SarModelSpec
+) -> Tuple[np.ndarray, np.ndarray, Tuple[float, ...], str]:
+    """Build the raw dB band stack in the model's channel order.
+
+    Steps 1-7 of the preprocessing contract: read VV on its own grid, read the other
+    polarizations aligned to it, intersect the validity masks, and derive difference
+    channels *before* any invalid-pixel fill so no fill value leaks into a subtraction.
+
+    Args:
+        file_paths (Sequence[str]): Per-polarization GeoTIFF paths for one scene.
+        spec (SarModelSpec): The model contract.
+
+    Returns:
+        Tuple: ``(stack float32 [C, H, W], valid bool [H, W], geotransform, projection)``
+        on the first required polarization's grid.
+    """
+    _check_speckle_filter(spec)
+    required = spec.required_polarizations
+    paths = resolve_scene_polarizations(file_paths, required)
+
+    reference_polarization = required[0]
+    values, valid, geotransform, projection = read_band(paths[reference_polarization])
+    bands: Dict[str, np.ndarray] = {reference_polarization: values}
+
+    for polarization in required[1:]:
+        other_values, other_valid = read_band_on_grid(
+            paths[polarization], geotransform, projection, valid.shape
+        )
+        bands[polarization] = other_values
+        valid = valid & other_valid
+
+    # A speckle filter would run here, per band, on raw dB. This model uses none.
+
+    stack = np.stack(
+        [_derive_channel(channel, bands) for channel in spec.channel_order]
+    ).astype(np.float32)
+    return stack, valid, geotransform, projection
+
+
+def preprocess(
+    stack: np.ndarray, valid: np.ndarray, spec: SarModelSpec
+) -> Tuple[np.ndarray, Tuple[int, int]]:
+    """Fill, normalize and pad a raw dB stack into the model's input tensor.
+
+    Steps 8-10 of the preprocessing contract. Invalid pixels are filled with the
+    per-channel mean so they land at exactly 0 after normalization, and padding is
+    applied bottom/right with 0.0 -- neutral, because the image is already normalized.
+    The image is never resized: the model was trained at the native ~10 m ground sample
+    distance and rescaling measurably degrades shoreline accuracy.
+
+    Args:
+        stack (np.ndarray): Raw dB channels ``[C, H, W]``.
+        valid (np.ndarray): Boolean validity mask ``[H, W]``.
+        spec (SarModelSpec): The model contract.
+
+    Returns:
+        Tuple[np.ndarray, Tuple[int, int]]: ``(input tensor [1, C, Hp, Wp], (H, W))``.
+    """
+    height, width = valid.shape
+    if height * width > MAX_INPUT_PIXELS:
+        raise SarModelError(
+            f"Scene is {height}x{width} ({height * width} pixels), above the "
+            f"{MAX_INPUT_PIXELS}-pixel limit for whole-scene SAR inference. "
+            "Reduce the ROI size and download again."
+        )
+
+    image = np.array(stack, dtype=np.float32, copy=True)
+    image[:, ~valid] = spec.mean[:, None]
+    image = (image - spec.mean[:, None, None]) / spec.std[:, None, None]
+
+    stride = spec.output_stride
+    padded_height = -(-height // stride) * stride
+    padded_width = -(-width // stride) * stride
+    tensor = np.zeros(
+        (1, image.shape[0], padded_height, padded_width), dtype=np.float32
+    )
+    tensor[0, :, :height, :width] = image
+    return tensor, (height, width)
+
+
+def postprocess(
+    water_prob: np.ndarray,
+    original_shape: Tuple[int, int],
+    valid: np.ndarray,
+    spec: SarModelSpec,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Crop the padding off, threshold, and stamp nodata back onto invalid pixels.
+
+    Args:
+        water_prob (np.ndarray): Model output, ``[1, 1, Hp, Wp]`` or any leading-axis
+            variant of it.
+        original_shape (Tuple[int, int]): ``(H, W)`` before padding.
+        valid (np.ndarray): Boolean validity mask ``[H, W]``.
+        spec (SarModelSpec): The model contract.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: ``(label uint8 [H, W], probability float32
+        [H, W])``. Labels use the model's class indices with ``spec.nodata`` at invalid
+        pixels; probabilities are NaN there.
+    """
+    height, width = original_shape
+    probability = np.asarray(water_prob, dtype=np.float32)
+    while probability.ndim > 2:
+        probability = probability[0]
+
+    probability = np.array(probability[:height, :width], dtype=np.float32, copy=True)
+
+    # Label with the model's own class indices instead of assuming water is 1. A
+    # retrained model may declare {0: "water", 1: "land"}, and extraction decodes
+    # grey_label through those same indices (merge_classes on
+    # model_info.water_class_indices). Emitting a fixed 1 would invert the mask on such
+    # a model rather than fail, which is exactly the desynchronization this module
+    # exists to prevent.
+    water_indices = spec.water_class_indices
+    water_index = water_indices[0] if water_indices else 1
+    land_index = next(
+        (index for index in sorted(spec.classes) if index not in water_indices), 0
+    )
+    label = np.where(
+        probability >= spec.water_threshold, water_index, land_index
+    ).astype(np.uint8)
+    label[~valid] = spec.nodata
+    probability[~valid] = np.nan
+    return label, probability
+
+
+@dataclass(frozen=True)
+class SarPrediction:
+    """One scene's segmentation, georeferenced on the reference polarization's grid."""
+
+    label: np.ndarray
+    water_prob: np.ndarray
+    valid: np.ndarray
+    georef: np.ndarray
+    projection: str
+
+
+def segment_scene(
+    file_paths: Sequence[str],
+    spec: SarModelSpec,
+    session: Optional["ort.InferenceSession"] = None,
+) -> SarPrediction:
+    """Segment one Sentinel-1 scene from its per-polarization GeoTIFFs.
+
+    Args:
+        file_paths (Sequence[str]): Per-polarization GeoTIFF paths for one scene.
+        spec (SarModelSpec): The model contract.
+        session (Optional[ort.InferenceSession]): Reusable session; created if omitted.
+
+    Returns:
+        SarPrediction: Labels, water probability and validity on the reference grid.
+    """
+    if session is None:
+        session = get_session(spec)
+
+    stack, valid, geotransform, projection = build_sar_stack(file_paths, spec)
+    tensor, original_shape = preprocess(stack, valid, spec)
+    outputs = session.run([spec.prob_output], {spec.input_name: tensor})
+    label, probability = postprocess(outputs[0], original_shape, valid, spec)
+    return SarPrediction(
+        label=label,
+        water_prob=probability,
+        valid=valid,
+        georef=np.asarray(geotransform, dtype=float),
+        projection=projection,
+    )
+
+
+def sar_nodata_mask(file_paths: Sequence[str]) -> Optional[np.ndarray]:
+    """Return the combined nodata mask for a scene, or None when it cannot be read.
+
+    Sentinel-1 scenes are swath crops, so a large share of a downloaded tile is often
+    empty. ``SDS_preprocess.preprocess_image`` reports an all-zero nodata mask for S1,
+    which lets those blank areas reach the shoreline contour finder. This recovers the
+    real mask from the GeoTIFFs.
+
+    Args:
+        file_paths (Sequence[str]): Per-polarization GeoTIFF paths for one scene.
+
+    Returns:
+        Optional[np.ndarray]: Boolean ``[H, W]`` mask, True where there is no data.
+    """
+    paths = [file_paths] if isinstance(file_paths, str) else list(file_paths)
+    if not paths:
+        return None
+    try:
+        _, valid, geotransform, projection = read_band(paths[0])
+        for path in paths[1:]:
+            _, other_valid = read_band_on_grid(
+                path, geotransform, projection, valid.shape
+            )
+            valid = valid & other_valid
+        return ~valid
+    except Exception as error:
+        logger.warning("Could not read the SAR nodata mask for %s: %s", paths, error)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Artifact writers
+# ---------------------------------------------------------------------------
+
+
+def _label_to_colors(
+    label: np.ndarray, nodata_mask: np.ndarray, class_count: int
+) -> np.ndarray:
+    """Colorize class indices with the shared palette; nodata pixels become black."""
+    palette = [
+        tuple(int(color.lstrip("#")[i : i + 2], 16) for i in (0, 2, 4))
+        for color in CLASS_LABEL_COLORMAP
+    ]
+    colored = np.zeros(label.shape[:2] + (3,), dtype=np.uint8)
+    for class_index in range(max(class_count, 1)):
+        colored[label == class_index] = palette[class_index % len(palette)]
+    colored[nodata_mask] = (0, 0, 0)
+    return colored
+
+
+def save_prediction_png(
+    prediction: SarPrediction, spec: SarModelSpec, output_path: Path
+) -> Path:
+    """Write the colorized ``*_predseg.png`` companion for a prediction."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    colored = _label_to_colors(
+        prediction.label, ~prediction.valid, len(spec.classes) or 1
+    )
+    Image.fromarray(colored, mode="RGB").save(output_path)
+    return output_path
+
+
+def save_prediction_npz(
+    prediction: SarPrediction,
+    spec: SarModelSpec,
+    input_file: str,
+    output_path: Path,
+) -> Path:
+    """Write the ``*_res.npz`` artifact the shoreline extraction reads.
+
+    ``grey_label`` carries the model's class indices with ``spec.nodata`` (255) at
+    invalid pixels. That is safe downstream because ``merge_classes`` builds its binary
+    mask with equality tests, so 255 simply is not water; nodata is excluded from
+    contour finding through the nodata mask instead.
+
+    ``nclasses`` is deliberately ``len(spec.classes)`` rather than ``label.max() + 1``,
+    which would be 256 once the nodata code is present.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "nclasses": len(spec.classes),
+        "n_data_bands": len(spec.channel_order),
+        "input_file": input_file,
+        "grey_label": prediction.label.astype(np.uint8),
+        "av_softmax_scores": prediction.water_prob.astype(np.float32),
+        "classes_to_index": dict(spec.classes),
+        # Extra provenance, ignored by the extraction path.
+        "nodata_mask": ~prediction.valid,
+        "water_threshold": np.float32(spec.water_threshold),
+        "channel_order": list(spec.channel_order),
+        "model_path": spec.onnx_path,
+    }
+    np.savez_compressed(str(output_path), **payload)
+    return output_path
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def write_model_settings_json(
+    session_directory: Path, model_directory: str, use_gpu: bool = False
+) -> Path:
+    """Write ``model_settings.json`` so the session can be resumed later."""
+    return _write_json(
+        session_directory / "model_settings.json",
+        {
+            "use_GPU": "1" if use_gpu else "0",
+            "implementation": "BEST",
+            "model_type": Path(model_directory).name,
+            "img_type": "SAR",
+        },
+    )
+
+
+def write_model_info_json(
+    session_directory: Path,
+    model_directory: str,
+    input_directory: str,
+    spec: SarModelSpec,
+) -> Path:
+    """Write ``model_info.json`` describing the class mapping and water classes."""
+    water_class_indices = spec.water_class_indices
+    return _write_json(
+        session_directory / "model_info.json",
+        {
+            "model_directory": str(Path(model_directory).expanduser().resolve()),
+            "input_directory": str(input_directory),
+            "class_mapping": {str(k): v for k, v in spec.classes.items()},
+            "water_class_indices": water_class_indices,
+            "water_classes": [
+                spec.classes[index]
+                for index in water_class_indices
+                if index in spec.classes
+            ],
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch driver
+# ---------------------------------------------------------------------------
+
+
+def _scene_key(filename: str) -> str:
+    """Group per-polarization files of the same acquisition under one key."""
+    basename = os.path.basename(filename)
+    polarization = get_polarization_from_filename(basename)
+    if polarization:
+        return _POLARIZATION_TOKEN_RE.sub("_POL", basename, count=1)
+    return basename
+
+
+def _output_stem(vv_filename: str) -> str:
+    """Build the artifact stem, matching what the TensorFlow zoo path produces.
+
+    ``{date}_RGB_S1`` mirrors the ``{date}_RGB_S1.jpg`` preview coastsat writes, which
+    is what ``find_matching_npz`` and ``find_satellite_in_filename`` key off. Any
+    ``_dupN`` suffix is preserved so duplicate acquisitions do not overwrite each other.
+    """
+    basename = os.path.basename(vv_filename)
+    stem = f"{basename[:19]}_RGB_S1"
+    duplicate = _DUP_TOKEN_RE.search(basename)
+    if duplicate:
+        stem = f"{stem}_{duplicate.group(1)}"
+    return stem
+
+
+def collect_sar_scenes(roi_directory: str) -> Dict[str, Dict[str, str]]:
+    """Group the Sentinel-1 GeoTIFFs under an ROI directory by acquisition.
+
+    Args:
+        roi_directory (str): ROI data directory, e.g. ``data/ID_x_datetime...``.
+
+    Returns:
+        Dict[str, Dict[str, str]]: ``{scene_key: {polarization: path}}``.
+    """
+    s1_root = Path(roi_directory) / "S1"
+    scenes: Dict[str, Dict[str, str]] = {}
+    for polarization in get_sar_polarizations():
+        folder = s1_root / polarization
+        if not folder.is_dir():
+            continue
+        for tif in sorted(folder.glob("*.tif")):
+            scenes.setdefault(_scene_key(tif.name), {})[polarization] = str(tif)
+    return scenes
+
+
+def run_sar_segmentation(
+    *,
+    roi_directory: str,
+    session_directory: str,
+    model_directory: str,
+    filenames: Optional[Sequence[str]] = None,
+    rgb_directory: str = "",
+    overwrite: bool = True,
+    use_gpu: bool = False,
+    water_threshold: Optional[float] = None,
+    progress_callback: Optional[Callable[[int, int, str], None]] = None,
+) -> Dict[str, Any]:
+    """Segment every dual-polarization Sentinel-1 scene in an ROI directory.
+
+    Writes ``*_predseg.png`` and ``*_res.npz`` per scene plus ``model_settings.json``,
+    ``model_info.json`` and ``segmentation_summary.json``, flat in ``session_directory``.
+
+    Args:
+        roi_directory (str): ROI data directory containing ``S1/<polarization>/``.
+        session_directory (str): Where the artifacts are written.
+        model_directory (str): Directory holding the exported ``.onnx`` model.
+        filenames (Optional[Sequence[str]]): Restrict to these scene filenames
+            (as listed in ``metadata['S1']['filenames']``). All scenes when omitted.
+        rgb_directory (str): RGB preview directory recorded in ``model_info.json``.
+        overwrite (bool): Re-run scenes whose artifacts already exist.
+        use_gpu (bool): Try the CUDA execution provider before CPU.
+        water_threshold (Optional[float]): ``P(water)`` cutoff. Overrides the value the
+            model records in its own metadata; that value is used when this is None.
+        progress_callback (Optional[Callable[[int, int, str], None]]): Called as
+            ``(current, total, scene_name)`` after each scene.
+
+    Returns:
+        Dict[str, Any]: Summary with counts, failures and the session directory.
+
+    Raises:
+        MissingPolarizationError: If no scene has every polarization the model needs.
+        SarModelError: If the model cannot be loaded.
+    """
+    session_path = Path(session_directory)
+    session_path.mkdir(parents=True, exist_ok=True)
+
+    spec = load_sar_model_spec(model_directory, use_gpu=use_gpu)
+    if water_threshold is not None:
+        # The user's setting wins over the cutoff baked into the model's metadata.
+        spec = replace(spec, water_threshold=float(water_threshold))
+    session = get_session(spec, use_gpu=use_gpu)
+    required = spec.required_polarizations
+
+    scenes = collect_sar_scenes(roi_directory)
+    if filenames:
+        wanted = {_scene_key(os.path.basename(name)) for name in filenames}
+        scenes = {key: paths for key, paths in scenes.items() if key in wanted}
+
+    complete = {
+        key: paths
+        for key, paths in scenes.items()
+        if all(polarization in paths for polarization in required)
+    }
+    incomplete = {key: paths for key, paths in scenes.items() if key not in complete}
+
+    if scenes and not complete:
+        available = sorted({p for paths in scenes.values() for p in paths})
+        raise MissingPolarizationError(
+            f"The SAR model needs {list(required)} but "
+            f"{os.path.join(roi_directory, 'S1')} only contains {available}. This site "
+            f"was downloaded before multi-polarization support. "
+            f"{describe_sar_polarization_remedy()}"
+        )
+
+    failures: List[Dict[str, str]] = []
+    for key, paths in sorted(incomplete.items()):
+        failures.append(
+            {
+                "image": key,
+                "error": f"missing polarizations "
+                f"{[p for p in required if p not in paths]}",
+            }
+        )
+    if incomplete:
+        logger.warning(
+            "Skipping %d Sentinel-1 scene(s) that lack a required polarization.",
+            len(incomplete),
+        )
+
+    written_masks = 0
+    written_npz = 0
+    skipped_existing = 0
+    total = len(complete)
+
+    for index, (key, paths) in enumerate(sorted(complete.items()), start=1):
+        reference_path = paths[required[0]]
+        stem = _output_stem(reference_path)
+        png_path = session_path / f"{stem}_predseg.png"
+        npz_path = session_path / f"{stem}_res.npz"
+
+        try:
+            if not overwrite and png_path.exists() and npz_path.exists():
+                skipped_existing += 1
+                continue
+
+            ordered_paths = [paths[polarization] for polarization in required]
+            prediction = segment_scene(ordered_paths, spec, session=session)
+
+            valid_fraction = float(prediction.valid.mean()) if prediction.valid.size else 0.0
+            logger.info("%s: %.1f%% of pixels are valid", stem, 100.0 * valid_fraction)
+
+            save_prediction_png(prediction, spec, png_path)
+            written_masks += 1
+            save_prediction_npz(prediction, spec, reference_path, npz_path)
+            written_npz += 1
+        except Exception as error:
+            logger.exception("SAR segmentation failed for %s", key)
+            failures.append({"image": key, "error": str(error)})
+        finally:
+            if progress_callback is not None:
+                progress_callback(index, total, stem)
+
+    input_directory = rgb_directory or os.path.join(
+        roi_directory, "jpg_files", "preprocessed", "RGB"
+    )
+    write_model_settings_json(session_path, model_directory, use_gpu=use_gpu)
+    write_model_info_json(session_path, model_directory, input_directory, spec)
+
+    summary: Dict[str, Any] = {
+        "session_directory": str(session_path),
+        "model_directory": str(Path(model_directory).expanduser().resolve()),
+        "total_images": total,
+        "written_masks": written_masks,
+        "written_npz": written_npz,
+        "skipped_existing": skipped_existing,
+        "failures": failures,
+    }
+    _write_json(session_path / "segmentation_summary.json", summary)
+    return summary

--- a/src/coastseg/zoo_model.py
+++ b/src/coastseg/zoo_model.py
@@ -23,6 +23,7 @@ from coastseg import (
     extracted_shoreline,
     file_utilities,
     geodata_processing,
+    sar_model,
 )
 from coastseg.intersections import save_transects, transect_timeseries
 from coastseg.model_info import ModelInfo
@@ -166,6 +167,8 @@ def get_imagery_directory(img_type: str, RGB_path: str) -> str:
     1. 'NDWI' for 'NIR'
     2. 'MNDWI' for 'SWIR'
     3. 'RGB' for 'RGB'
+    4. 'SAR' for 'RGB' (no conversion; the SAR model reads the Sentinel-1 GeoTIFFs
+       directly, and the RGB previews are only used to name outputs)
 
     Note:
         Directories containing 'NIR','NIR' and 'RGB' imagery must be at the same level as the 'RGB' imagery.
@@ -176,7 +179,7 @@ def get_imagery_directory(img_type: str, RGB_path: str) -> str:
             SWIR
 
     Args:
-        img_type (str): The type of imagery to generate. Available options: 'RGB', 'NDWI', 'MNDWI'
+        img_type (str): The type of imagery to generate. Available options: 'RGB', 'NDWI', 'MNDWI', 'SAR'
         RGB_path (str): The path to the RGB imagery directory.
 
     Returns:
@@ -185,6 +188,10 @@ def get_imagery_directory(img_type: str, RGB_path: str) -> str:
     img_type = img_type.upper()
     output_path = os.path.dirname(RGB_path)
     if img_type == "RGB":
+        output_path = RGB_path
+    elif img_type == "SAR":
+        # The Sentinel-1 ONNX model reads data/<site>/S1/<polarization>/*.tif, not
+        # jpgs. The RGB preview directory is still what identifies the scenes.
         output_path = RGB_path
     # default filetype is NIR and if NDWI is selected else filetype to SWIR
     elif img_type == "NDWI":
@@ -195,7 +202,7 @@ def get_imagery_directory(img_type: str, RGB_path: str) -> str:
         output_path = RGB_to_infrared(RGB_path, SWIR_path, output_path, "MNDWI")
     else:
         raise ValueError(
-            f"{img_type} not reconigzed as one of the valid types 'RGB', 'NDWI', 'MNDWI'"
+            f"{img_type} not reconigzed as one of the valid types 'RGB', 'NDWI', 'MNDWI', 'SAR'"
         )
     return output_path
 
@@ -1115,6 +1122,14 @@ class Zoo_Model:
             "drop_intersection_pts": False,  # whether to drop intersection points not on the transect
             "coastseg_version": __version__,  # version of coastseg used to generate the data
             "apply_segmentation_filter": False,  # whether to apply to sort the segmentations as good or bad
+            # Sentinel-1 only: mask the empty parts of a SAR swath so they are excluded
+            # from the shoreline contour search instead of being traced as land
+            "sar_mask_nodata": True,
+            # Sentinel-1 only: re-segment scenes whose outputs already exist
+            "sar_overwrite_segmentation": True,
+            # Sentinel-1 only: P(water) cutoff the segmentation model thresholds at.
+            # Same key the coastsat workflow reads, so one setting drives both paths.
+            "sar_water_threshold": 0.5,
         }
         if kwargs:
             self.settings.update({key: value for key, value in kwargs.items()})
@@ -1198,6 +1213,33 @@ class Zoo_Model:
         """
         return retrieve_model_weights(self.weights_directory, model_choice)
 
+    def _resolve_local_model_path(
+        self, model_setting: Dict[str, Any], is_sar_request: bool
+    ) -> str:
+        """Return the configured local model path, tolerating an absent SAR directory.
+
+        Args:
+            model_setting (Dict[str, Any]): Model settings for the run.
+            is_sar_request (bool): Whether ``img_type`` selects the SAR model.
+
+        Returns:
+            str: Configured local model path, or ``""`` when none is set.
+
+        Raises:
+            FileNotFoundError: If a non-SAR ``local_model_path`` does not exist.
+        """
+        try:
+            return self.get_local_model_path(model_setting)
+        except FileNotFoundError:
+            # The SAR model is downloaded on first use, so its directory is
+            # legitimately absent on a fresh clone -- the same reason
+            # is_sar_model_directory answers True for it before the download.
+            # Every other missing path is still a genuine mistake.
+            configured_path = str(model_setting.get("local_model_path", "")).strip()
+            if is_sar_request and sar_model.is_sar_model_directory(configured_path):
+                return configured_path
+            raise
+
     def resolve_model_directory(self, model_setting: Dict[str, Any]) -> str:
         """Resolve a runnable model directory for the current settings.
 
@@ -1212,10 +1254,18 @@ class Zoo_Model:
             FileNotFoundError: If required model files are unavailable.
         """
         implementation = str(model_setting.get("implementation", "BEST")).upper()
+        is_sar_request = str(model_setting.get("img_type", "")).upper() == "SAR"
 
-        local_model_path = self.get_local_model_path(model_setting)
+        local_model_path = self._resolve_local_model_path(model_setting, is_sar_request)
         if local_model_path:
             model_directory = Path(local_model_path)
+        elif is_sar_request:
+            # 'SAR' names an image type, not a zoo model id. Without this branch an
+            # unset 'local_model_path' sends "SAR_segmentation_model" to the zoo
+            # downloader, which looks it up on Zenodo and fails with a 404. The UI
+            # never reaches here because it populates 'local_model_path' itself;
+            # scripts and notebooks that set only 'img_type' do.
+            model_directory = Path(sar_model.get_sar_model_directory())
         else:
             model_id = str(model_setting.get("model_type", "")).strip()
             if not model_id:
@@ -1227,8 +1277,29 @@ class Zoo_Model:
                 self.ensure_model_downloaded(implementation, model_id)[0]
             )
 
-        retrieve_model_weights(str(model_directory), implementation)
-        ModelInfo(model_directory=str(model_directory)).load()
+        if sar_model.is_sar_model_directory(str(model_directory)):
+            # ONNX SAR model: no .h5 weights to resolve. Loading the spec validates the
+            # file and its embedded preprocessing contract.
+            sar_model.load_sar_model_spec(str(model_directory))
+        elif is_sar_request:
+            # Only reachable when 'local_model_path' was pointed somewhere that is
+            # neither the designated SAR directory nor a directory holding a .onnx --
+            # the designated one downloads the model instead of failing. Fail on the
+            # actual problem instead of the confusing "no BEST_MODEL.txt" error
+            # retrieve_model_weights would raise for a directory with no .h5.
+            raise FileNotFoundError(
+                f"'SAR' was selected but {model_directory} does not contain a .onnx "
+                "model. Point 'local_model_path' at the directory holding your model, "
+                f"or leave it as models/{sar_model.DEFAULT_SAR_MODEL_DIRNAME} to have "
+                "the default model downloaded automatically."
+            )
+        else:
+            retrieve_model_weights(str(model_directory), implementation)
+            # Validation only -- the result is discarded. Skipped for SAR, where
+            # load_sar_model_spec above is the real check: ModelInfo needs a
+            # modelcard a bare downloaded .onnx does not have, and would fall back
+            # to the 4-class Zoo mapping whose water indices are wrong for SAR.
+            ModelInfo(model_directory=str(model_directory)).load()
 
         self.weights_directory = str(model_directory)
         logger.info("Using model directory: %s", model_directory)
@@ -1282,9 +1353,48 @@ class Zoo_Model:
         return current_path
 
     def run_model(
-        self, model_setting: dict, sample_directory: str, session_directory: str
+        self,
+        model_setting: dict,
+        sample_directory: str,
+        session_directory: str,
+        roi_directory: str = "",
     ) -> None:
+        """Run the configured model over an ROI's imagery.
+
+        SAR models run in-process via onnxruntime; the SegFormer models run in the
+        separate TensorFlow environment.
+
+        Args:
+            model_setting (dict): Model configuration for this run.
+            sample_directory (str): Directory of preprocessed imagery (the RGB dir).
+            session_directory (str): Directory the segmentation outputs are written to.
+            roi_directory (str): ROI data directory, required for the SAR path because
+                the model reads the Sentinel-1 GeoTIFFs rather than the jpg previews.
+        """
         model_directory = self.resolve_model_directory(model_setting)
+
+        if sar_model.is_sar_model_directory(model_directory):
+            if not roi_directory:
+                raise ValueError(
+                    "The SAR model reads Sentinel-1 GeoTIFFs, so the ROI directory "
+                    "containing the S1 folder must be provided."
+                )
+            summary = sar_model.run_sar_segmentation(
+                roi_directory=roi_directory,
+                session_directory=session_directory,
+                model_directory=model_directory,
+                rgb_directory=sample_directory,
+                overwrite=model_setting.get("sar_overwrite_segmentation", True),
+                use_gpu=(model_setting.get("use_GPU", "0") == "1"),
+                water_threshold=model_setting.get("sar_water_threshold"),
+            )
+            print(
+                f"Segmented {summary['written_npz']} of {summary['total_images']} "
+                f"Sentinel-1 scenes."
+            )
+            if summary["failures"]:
+                print(f"{len(summary['failures'])} scene(s) failed or were skipped.")
+            return
 
         run_segmentation_in_external_env(
             input_dir=sample_directory,
@@ -1347,6 +1457,7 @@ class Zoo_Model:
             session_directory=os.path.join(
                 core_utilities.get_base_dir(), "sessions", session_name
             ),
+            roi_directory=roi_directory,
         )
 
     def run_model_and_extract_shorelines(
@@ -1706,6 +1817,20 @@ class Zoo_Model:
             model_directory = self.weights_directory
             if not model_directory or not os.path.isdir(model_directory):
                 model_directory = self.resolve_model_directory(settings)
+
+        # A SAR ONNX directory carries no *modelcard.json: the model is downloaded as a
+        # bare .onnx into coastsat's cache, and a user who supplies their own drops in
+        # one file. ModelInfo.load() would then silently fall back to the 4-class Zoo
+        # mapping, whose water indices are [0, 1] -- which on SAR's {0: land, 1: water}
+        # labels marks the whole raster as water and yields no shoreline at all. The
+        # .onnx records its own classes, so read them from there.
+        if sar_model.is_sar_model_directory(model_directory):
+            spec = sar_model.load_sar_model_spec(model_directory)
+            model_info = ModelInfo(
+                model_directory=model_directory, class_mapping=dict(spec.classes)
+            )
+            model_info.load()
+            return model_info
 
         model_info = ModelInfo(model_directory=model_directory)
         model_info.load()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1541,3 +1541,219 @@ def triangle_polygon_gdf():
     return gpd.GeoDataFrame(
         geometry=[Polygon([(0, 0), (1, 1), (1, 0)])], crs="EPSG:4326"
     )
+
+
+# ---------------------------------------------------------------------------
+# Sentinel-1 / SAR fixtures
+# ---------------------------------------------------------------------------
+
+SAR_SCENE_DATE = "2023-05-01-04-26-29"
+SAR_SITENAME = "ID_test_datetime01-01-25__00_00_00"
+SAR_MODEL_DIR = os.path.join(
+    os.path.dirname(script_dir), "models", "SAR_segmentation_model"
+)
+
+
+def write_sar_tif(
+    path,
+    array,
+    nodata=-9999.0,
+    geotransform=(500000.0, 10.0, 0.0, 4000000.0, 0.0, -10.0),
+    epsg=32610,
+):
+    """Write a single-band float32 GeoTIFF with an explicit nodata value.
+
+    The nodata value matters: GDAL's mask band is derived from it, and an
+    all-valid mask would make the validity tests vacuous.
+    """
+    from osgeo import gdal, osr
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    dataset = gdal.GetDriverByName("GTiff").Create(
+        path, array.shape[1], array.shape[0], 1, gdal.GDT_Float32
+    )
+    dataset.SetGeoTransform(geotransform)
+    spatial_reference = osr.SpatialReference()
+    spatial_reference.ImportFromEPSG(epsg)
+    dataset.SetProjection(spatial_reference.ExportToWkt())
+    band = dataset.GetRasterBand(1)
+    band.SetNoDataValue(nodata)
+    band.WriteArray(array)
+    dataset = None
+    return path
+
+
+def build_sar_bands(height=50, width=70, nodata_rows=6, nodata=-9999.0):
+    """Return (vv, vh) dB arrays: low-backscatter water left, land right."""
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    columns = np.arange(width)[None, :]
+    vv = np.where(columns < width // 2, -22.0, -8.0) + rng.normal(0, 1.0, (height, width))
+    vh = np.where(columns < width // 2, -30.0, -15.0) + rng.normal(0, 1.0, (height, width))
+    if nodata_rows:
+        vv[-nodata_rows:, :] = nodata
+    return vv.astype("float32"), vh.astype("float32")
+
+
+@pytest.fixture
+def sar_scene_tifs(tmp_path):
+    """A dual-polarization Sentinel-1 site laid out the way coastsat downloads it."""
+    site = tmp_path / SAR_SITENAME
+    vv, vh = build_sar_bands()
+    paths = {}
+    for polarization, array in (("VV", vv), ("VH", vh)):
+        paths[polarization] = write_sar_tif(
+            str(site / "S1" / polarization / f"{SAR_SCENE_DATE}_S1_test_{polarization}.tif"),
+            array,
+        )
+    rgb = site / "jpg_files" / "preprocessed" / "RGB"
+    rgb.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (10, 10)).save(str(rgb / f"{SAR_SCENE_DATE}_RGB_S1.jpg"))
+    meta = site / "S1" / "meta"
+    meta.mkdir(parents=True, exist_ok=True)
+    (meta / f"{SAR_SCENE_DATE}_S1_test.txt").write_text(
+        "filename\t%s_S1_test_VV.tif\nband_order\t['VV', 'VH']\n" % SAR_SCENE_DATE
+    )
+    return {
+        "site": str(site),
+        "vv": paths["VV"],
+        "vh": paths["VH"],
+        "rgb_directory": str(rgb),
+        "shape": (50, 70),
+        "nodata_rows": 6,
+    }
+
+
+@pytest.fixture
+def sar_site_vh_only(tmp_path):
+    """A legacy site downloaded before multi-polarization support (VH only)."""
+    site = tmp_path / "ID_legacy_datetime01-01-20__00_00_00"
+    _, vh = build_sar_bands(nodata_rows=0)
+    path = write_sar_tif(
+        str(site / "S1" / "VH" / f"{SAR_SCENE_DATE}_S1_legacy_VH.tif"), vh
+    )
+    return {"site": str(site), "vh": path}
+
+
+@pytest.fixture
+def sar_grid_mismatch_tifs(tmp_path):
+    """VV and VH on different grids, forcing the reprojection fallback."""
+    site = tmp_path / "ID_mismatch_datetime01-01-25__00_00_00"
+    vv, _ = build_sar_bands(height=64, width=64, nodata_rows=0)
+    _, vh = build_sar_bands(height=32, width=32, nodata_rows=0)
+    vv_path = write_sar_tif(
+        str(site / "S1" / "VV" / f"{SAR_SCENE_DATE}_S1_mismatch_VV.tif"), vv
+    )
+    # half the resolution, same origin, so the grids genuinely differ
+    vh_path = write_sar_tif(
+        str(site / "S1" / "VH" / f"{SAR_SCENE_DATE}_S1_mismatch_VH.tif"),
+        vh,
+        geotransform=(500000.0, 20.0, 0.0, 4000000.0, 0.0, -20.0),
+    )
+    return {"site": str(site), "vv": vv_path, "vh": vh_path, "shape": (64, 64)}
+
+
+@pytest.fixture
+def sar_model_spec_stub():
+    """A SarModelSpec built from literals, so tests never load the real 130 MB model."""
+    import numpy as np
+
+    from coastseg.sar_model import SarModelSpec
+
+    return SarModelSpec(
+        onnx_path="stub.onnx",
+        input_name="image",
+        prob_output="water_prob",
+        channel_order=("VV", "VH", "VV-VH"),
+        mean=np.array([-12.59, -20.26, 10.5465], dtype=np.float32),
+        std=np.array([5.26, 5.91, 7.6855], dtype=np.float32),
+        output_stride=32,
+        nodata=255,
+        classes={0: "land", 1: "water"},
+        input_scale="dB",
+        speckle_filter={"type": "none"},
+    )
+
+
+@pytest.fixture
+def sar_tif_writer():
+    """Expose the SAR raster helpers to tests that need to build extra scenes."""
+    return build_sar_bands, write_sar_tif
+
+
+@pytest.fixture
+def s1_download_inputs(tmp_path):
+    """The per-ROI ``inputs`` block CoastSeg hands to coastsat for a Sentinel-1 download.
+
+    Nothing is written to disk, matching a download that has not run yet.
+    """
+    return {
+        "roi_id": "roi1",
+        "sitename": SAR_SITENAME,
+        "filepath": str(tmp_path),
+        "sat_list": ["S1"],
+        "dates": ["2023-01-01", "2023-06-01"],
+        "landsat_collection": "C02",
+        "sentinel_1_properties": {
+            "transmitterReceiverPolarisation": ["VV", "VH"],
+            "instrumentMode": "IW",
+        },
+    }
+
+
+@pytest.fixture
+def sar_legacy_site_with_meta(tmp_path):
+    """A VH-only site that also carries the coastsat metadata file for its one scene.
+
+    ``sar_site_vh_only`` has no ``S1/meta`` directory, and ``get_metadata`` needs one to
+    build the ``band_order`` list the resume check reads. Kept separate so the tests
+    already using that fixture are unaffected.
+
+    The returned dict exposes ``add_vv()``, which writes the VV sibling the way a resumed
+    download would -- same sitename, same scene date, no ``_dup`` suffix.
+    """
+    sitename = "ID_legacy_datetime01-01-20__00_00_00"
+    site = tmp_path / sitename
+    _, vh = build_sar_bands(nodata_rows=0)
+    vv, _ = build_sar_bands(nodata_rows=0)
+    stem = f"{SAR_SCENE_DATE}_S1_legacy"
+
+    vh_path = write_sar_tif(str(site / "S1" / "VH" / f"{stem}_VH.tif"), vh)
+    meta = site / "S1" / "meta"
+    meta.mkdir(parents=True, exist_ok=True)
+    meta_path = meta / f"{stem}.txt"
+    meta_path.write_text(
+        f"filename\t{stem}_VH.tif\nepsg\t32610\nim_width\t70\nim_height\t50\n"
+        "band_order\t['VH']\n"
+    )
+
+    def add_vv():
+        """Backfill the VV band into the existing site, as a resumed download does."""
+        vv_path = write_sar_tif(str(site / "S1" / "VV" / f"{stem}_VV.tif"), vv)
+        meta_path.write_text(
+            f"filename\t{stem}_VV.tif\nepsg\t32610\nim_width\t70\nim_height\t50\n"
+            "band_order\t['VV', 'VH']\n"
+        )
+        return vv_path
+
+    return {
+        "site": str(site),
+        "sitename": sitename,
+        "filepath": str(tmp_path),
+        "vh": vh_path,
+        "meta": str(meta_path),
+        "scene_date": SAR_SCENE_DATE,
+        "add_vv": add_vv,
+        "inputs": {
+            "roi_id": "legacy1",
+            "sitename": sitename,
+            "filepath": str(tmp_path),
+            "sat_list": ["S1"],
+            "dates": ["2023-01-01", "2023-06-01"],
+            "sentinel_1_properties": {
+                "transmitterReceiverPolarisation": ["VV", "VH"],
+                "instrumentMode": "IW",
+            },
+        },
+    }

--- a/tests/test_filter_images_by_raster.py
+++ b/tests/test_filter_images_by_raster.py
@@ -1,0 +1,180 @@
+"""Tests for measuring a scene's footprint from its GeoTIFF rather than its preview jpg.
+
+`filter_images` used to infer ground area from the preview's pixel dimensions. That holds
+for optical, whose preview is a raw raster write, but coastsat renders the Sentinel-1
+preview as a titled matplotlib figure -- figsize x dpi, plus axes and whitespace. Measuring
+that made every S1 scene look several times larger than its ROI, so all of them were
+rejected as oversized and moved to `bad`.
+"""
+
+import os
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from coastseg import common
+
+
+PIXEL_SIZE = {"S1": 10, "S2": 10, "L8": 15}
+
+
+def write_tif(path, width, height, pixel_size, epsg=32610):
+    """A minimal georeferenced GeoTIFF of the given size."""
+    from osgeo import gdal, osr
+
+    gdal.UseExceptions()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    dataset = gdal.GetDriverByName("GTiff").Create(path, width, height, 1, gdal.GDT_Float32)
+    dataset.SetGeoTransform((500000.0, pixel_size, 0.0, 4000000.0, 0.0, -pixel_size))
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(epsg)
+    dataset.SetProjection(srs.ExportToWkt())
+    dataset.GetRasterBand(1).WriteArray(np.ones((height, width), dtype=np.float32))
+    dataset = None
+    return path
+
+
+def write_jpg(path, width, height):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Image.new("RGB", (width, height), (128, 128, 128)).save(path)
+    return path
+
+
+@pytest.fixture
+def s1_site(tmp_path):
+    """A 448x448 S1 scene (20.07 km2) whose preview is a much larger figure."""
+    site = tmp_path / "ID_test_datetime01-01-26__00_00_00"
+    date = "2023-05-06-02-07-48"
+    write_tif(str(site / "S1" / "VV" / f"{date}_S1_site_VV.tif"), 448, 448, 10)
+    write_tif(str(site / "S1" / "VH" / f"{date}_S1_site_VH.tif"), 448, 448, 10)
+    rgb = site / "jpg_files" / "preprocessed" / "RGB"
+    write_jpg(str(rgb / f"{date}_RGB_S1.jpg"), 962, 988)  # the matplotlib figure
+    return {"site": str(site), "rgb": str(rgb), "date": date}
+
+
+# ---------------------------------------------------------------------------
+# calculate_raster_area
+# ---------------------------------------------------------------------------
+
+
+def test_area_comes_from_the_geotransform_not_a_hardcoded_table(tmp_path):
+    path = write_tif(str(tmp_path / "scene.tif"), 448, 448, 10)
+
+    # the fallback pixel size is deliberately wrong; the geotransform must win
+    assert common.calculate_raster_area(path, pixel_size=999) == pytest.approx(20.0704)
+
+
+def test_a_missing_raster_is_zero_rather_than_an_exception(tmp_path):
+    assert common.calculate_raster_area(str(tmp_path / "nope.tif")) == 0.0
+
+
+def test_landsat_pixel_size_is_read_correctly(tmp_path):
+    path = write_tif(str(tmp_path / "l8.tif"), 300, 300, 15)
+
+    assert common.calculate_raster_area(path) == pytest.approx(20.25)
+
+
+# ---------------------------------------------------------------------------
+# find_source_raster
+# ---------------------------------------------------------------------------
+
+
+def test_an_s1_preview_resolves_to_a_polarization_tif(s1_site):
+    found = common.find_source_raster(f"{s1_site['date']}_RGB_S1.jpg", s1_site["site"])
+
+    assert found is not None
+    assert found.endswith(".tif")
+    assert os.path.join("S1", "VV") in found  # canonical order, VV first
+
+
+def test_an_s1_preview_still_resolves_when_only_vh_exists(tmp_path):
+    """A legacy VH-only site must not lose its size filter."""
+    site = tmp_path / "site"
+    date = "2023-05-06-02-07-48"
+    write_tif(str(site / "S1" / "VH" / f"{date}_S1_site_VH.tif"), 448, 448, 10)
+
+    found = common.find_source_raster(f"{date}_RGB_S1.jpg", str(site))
+
+    assert found is not None and os.path.join("S1", "VH") in found
+
+
+def test_an_optical_preview_resolves_to_the_ms_tif(tmp_path):
+    site = tmp_path / "site"
+    date = "2023-06-16-15-53-12"
+    write_tif(str(site / "S2" / "ms" / f"{date}_S2_site_ms.tif"), 456, 456, 10)
+
+    found = common.find_source_raster(f"{date}_RGB_S2.jpg", str(site))
+
+    assert found is not None and os.path.join("S2", "ms") in found
+
+
+def test_no_raster_resolves_to_none(tmp_path):
+    assert common.find_source_raster("2023-06-16-15-53-12_RGB_S2.jpg", str(tmp_path)) is None
+    assert common.find_source_raster("2023-06-16-15-53-12_RGB_S2.jpg", "") is None
+
+
+# ---------------------------------------------------------------------------
+# filter_images
+# ---------------------------------------------------------------------------
+
+
+def test_an_s1_scene_matching_its_roi_is_kept(s1_site):
+    """The regression: a 20.07 km2 scene inside a 20 km2 ROI's 8-30 km2 window.
+
+    Measured from the 962x988 preview it comes out at 95 km2 and is rejected.
+    """
+    bad = common.filter_images(8.0, 30.0, s1_site["rgb"], roi_directory=s1_site["site"])
+
+    assert bad == []
+    assert os.path.exists(os.path.join(s1_site["rgb"], f"{s1_site['date']}_RGB_S1.jpg"))
+
+
+def test_the_preview_alone_would_have_rejected_it(s1_site):
+    """Pins why the fix is needed: without the GeoTIFF the same scene fails."""
+    bad = common.filter_images(8.0, 30.0, s1_site["rgb"])  # no roi_directory
+
+    # S1 is skipped rather than judged on a meaningless number
+    assert bad == []
+    jpg = os.path.join(s1_site["rgb"], f"{s1_site['date']}_RGB_S1.jpg")
+    assert common.calculate_image_area(jpg, 10) > 30.0  # what the old code measured
+
+
+def test_a_genuinely_partial_s1_scene_is_still_rejected(s1_site):
+    """The filter must keep doing its job, not just pass everything."""
+    date = "2023-05-18-02-07-49"
+    write_tif(str(os.path.join(s1_site["site"], "S1", "VV", f"{date}_S1_site_VV.tif")),
+              448, 100, 10)  # ~4.5 km2, well under the 8 km2 floor
+    write_jpg(os.path.join(s1_site["rgb"], f"{date}_RGB_S1.jpg"), 962, 988)
+
+    bad = common.filter_images(8.0, 30.0, s1_site["rgb"], roi_directory=s1_site["site"])
+
+    assert [os.path.basename(f) for f in bad] == [f"{date}_RGB_S1.jpg"]
+
+
+def test_optical_results_are_unchanged_by_measuring_the_raster(tmp_path):
+    """Optical previews are raw raster writes, so both routes must agree."""
+    site = tmp_path / "site"
+    rgb = site / "jpg_files" / "preprocessed" / "RGB"
+    date = "2017-12-09-16-57-21"
+    write_tif(str(site / "L8" / "ms" / f"{date}_L8_site_ms.tif"), 300, 300, 15)
+    jpg = write_jpg(str(rgb / f"{date}_RGB_L8.jpg"), 300, 300)
+
+    from_raster = common.calculate_raster_area(
+        common.find_source_raster(os.path.basename(jpg), str(site))
+    )
+
+    assert from_raster == pytest.approx(common.calculate_image_area(jpg, 15))
+    assert common.filter_images(8.0, 30.0, str(rgb), roi_directory=str(site)) == []
+
+
+def test_bad_images_are_moved_into_the_bad_folder(s1_site):
+    date = "2023-05-18-02-07-49"
+    write_tif(str(os.path.join(s1_site["site"], "S1", "VV", f"{date}_S1_site_VV.tif")),
+              448, 100, 10)
+    write_jpg(os.path.join(s1_site["rgb"], f"{date}_RGB_S1.jpg"), 962, 988)
+
+    common.filter_images(8.0, 30.0, s1_site["rgb"], roi_directory=s1_site["site"])
+
+    assert os.path.isfile(os.path.join(s1_site["rgb"], "bad", f"{date}_RGB_S1.jpg"))
+    assert not os.path.isfile(os.path.join(s1_site["rgb"], f"{date}_RGB_S1.jpg"))

--- a/tests/test_model_info.py
+++ b/tests/test_model_info.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from coastseg.model_info import DEFAULT_CLASS_MAPPING, ModelInfo
+
+
+def test_model_info_loads_from_model_info_json(tmp_path: Path) -> None:
+    payload = {
+        "model_directory": str(tmp_path),
+        "input_directory": str(tmp_path / "input"),
+        "class_mapping": {
+            "0": "water",
+            "1": "whitewater",
+            "2": "sediment",
+            "3": "other",
+        },
+        "water_class_indices": [0, 1],
+        "water_classes": ["water", "whitewater"],
+    }
+    (tmp_path / "model_info.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    model_info = ModelInfo(model_directory=str(tmp_path))
+    model_info.load_from_model_info_file(
+        model_info_path=str(tmp_path / "model_info.json")
+    )
+
+    assert model_info.class_mapping == {
+        0: "water",
+        1: "whitewater",
+        2: "sediment",
+        3: "other",
+    }
+    assert model_info.water_class_indices == [0, 1]
+    assert model_info.input_directory == str(tmp_path / "input")
+
+
+def test_model_info_accepts_direct_model_info_path(tmp_path: Path) -> None:
+    model_info_json = tmp_path / "model_info.json"
+    payload = {
+        "class_mapping": {
+            "0": "water",
+            "1": "whitewater",
+        },
+        "water_class_indices": [0, 1],
+    }
+    model_info_json.write_text(json.dumps(payload), encoding="utf-8")
+
+    model_info = ModelInfo(model_info_path=str(model_info_json))
+    model_info.load_from_model_info_file()
+
+    assert model_info.model_info_path == str(model_info_json.resolve())
+    assert model_info.model_directory == str(tmp_path.resolve())
+    assert model_info.class_mapping == {0: "water", 1: "whitewater"}
+    assert model_info.water_class_indices == [0, 1]
+
+
+def test_model_info_accepts_model_directory_as_model_info_file(tmp_path: Path) -> None:
+    model_info_json = tmp_path / "model_info.json"
+    payload = {
+        "class_mapping": {
+            "0": "water",
+            "1": "whitewater",
+            "2": "sediment",
+        },
+        "water_classes": ["water"],
+    }
+    model_info_json.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError):
+        ModelInfo(model_directory=str(model_info_json))
+
+
+def test_model_info_resolves_water_indices_from_names(tmp_path: Path) -> None:
+    payload = {
+        "class_mapping": {
+            "0": "water",
+            "1": "whitewater",
+            "2": "sediment",
+        },
+        "water_classes": ["whitewater"],
+    }
+    (tmp_path / "model_info.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    model_info = ModelInfo(model_directory=str(tmp_path))
+    model_info.load_from_model_info_file(
+        model_info_path=str(tmp_path / "model_info.json")
+    )
+
+    assert model_info.class_mapping[1] == "whitewater"
+    assert model_info.water_class_indices == [1]
+
+
+def test_model_info_defaults_without_modelcard_or_model_info(tmp_path: Path) -> None:
+    model_info = ModelInfo(model_directory=str(tmp_path))
+    assert model_info.class_mapping == DEFAULT_CLASS_MAPPING
+    assert model_info.water_class_indices == [0, 1]
+
+
+def test_model_info_can_load_with_stored_model_info_path_only(tmp_path: Path) -> None:
+    model_info_json = tmp_path / "model_info.json"
+    model_info_json.write_text(
+        json.dumps({"class_mapping": {"0": "water"}}),
+        encoding="utf-8",
+    )
+
+    model_info = ModelInfo(model_info_path=str(model_info_json))
+    model_info.load_from_model_info_file()
+
+    assert model_info.class_mapping == {0: "water"}
+
+
+def test_model_info_load_from_model_info_file_raises_if_missing(tmp_path: Path) -> None:
+    model_info = ModelInfo(model_directory=str(tmp_path))
+
+    with pytest.raises(FileNotFoundError):
+        model_info.load_from_model_info_file(
+            model_info_path=str(tmp_path / "model_info.json")
+        )

--- a/tests/test_sar_band_order_metadata.py
+++ b/tests/test_sar_band_order_metadata.py
@@ -1,0 +1,173 @@
+"""Tests for reading Sentinel-1 `band_order` out of a scene's metadata .txt file.
+
+coastsat writes one metadata file per S1 scene carrying the polarizations it downloaded.
+CoastSeg keeps its own copy of `get_metadata`, which used to drop that key entirely.
+coastsat reads it back when it cannot list the files on disk -- for example to tell a
+complete scene from one still missing a band -- so it has to survive the round trip and
+stay index-aligned with `filenames`.
+"""
+
+import os
+
+import pytest
+
+from coastseg import extracted_shoreline as es
+
+
+LEGACY_META = """\
+filename\t2024-08-02-08-39-41_S1_site_VH.tif
+epsg\t32756
+im_width\t168
+im_height\t436
+orbitProperties_pass\tASCENDING
+transmitterReceiverPolarisation\t['VV', 'VH']
+saved_polarization\tVH
+instrumentMode\tIW
+"""
+
+DUAL_POL_META = """\
+filename\t2023-12-03-19-15-49_S1_site_VV.tif
+epsg\t32756
+im_width\t168
+im_height\t436
+band_order\t['VV', 'VH']
+orbitProperties_pass\tDESCENDING
+transmitterReceiverPolarisation\t['VV', 'VH']
+instrumentMode\tIW
+"""
+
+
+def write_meta(directory, filename, contents):
+    path = os.path.join(directory, filename)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(contents)
+    return path
+
+
+@pytest.fixture
+def s1_site(tmp_path):
+    """A site whose meta folder the caller fills in."""
+    meta_dir = tmp_path / "site" / "S1" / "meta"
+    meta_dir.mkdir(parents=True)
+    return tmp_path, meta_dir
+
+
+def read_s1_metadata(root, dates=("2020-01-01", "2030-01-01")):
+    return es.get_metadata(
+        {
+            "filepath": str(root),
+            "sitename": "site",
+            "sat_list": ["S1"],
+            "dates": list(dates),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# read_metadata_file
+# ---------------------------------------------------------------------------
+
+
+def test_band_order_is_parsed_into_a_list(tmp_path):
+    path = write_meta(str(tmp_path), "scene.txt", DUAL_POL_META)
+
+    assert es.read_metadata_file(path)["band_order"] == ["VV", "VH"]
+
+
+def test_a_legacy_file_has_no_band_order(tmp_path):
+    path = write_meta(str(tmp_path), "scene.txt", LEGACY_META)
+    meta_info = es.read_metadata_file(path)
+
+    assert meta_info["band_order"] == []
+    assert meta_info["saved_polarization"] == "VH"
+
+
+def test_a_malformed_band_order_does_not_break_the_read(tmp_path, caplog):
+    """band_order is optional; a bad value must not take down the whole file."""
+    path = write_meta(
+        str(tmp_path), "scene.txt", DUAL_POL_META.replace("['VV', 'VH']", "[VV, VH")
+    )
+
+    with caplog.at_level("WARNING"):
+        meta_info = es.read_metadata_file(path)
+
+    assert meta_info["band_order"] == []
+    assert meta_info["epsg"] == 32756  # the rest of the file still parsed
+    assert "band_order" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# get_band_order_from_meta
+# ---------------------------------------------------------------------------
+
+
+def test_band_order_wins_over_saved_polarization():
+    resolved = es.get_band_order_from_meta(
+        {"band_order": ["VV", "VH"], "saved_polarization": "VH"}
+    )
+    assert resolved == ["VV", "VH"]
+
+
+def test_a_legacy_scene_falls_back_to_saved_polarization():
+    assert es.get_band_order_from_meta({"saved_polarization": "VH"}) == ["VH"]
+
+
+def test_neither_key_resolves_to_empty():
+    assert es.get_band_order_from_meta({"filename": "x.tif"}) == []
+
+
+def test_the_requested_polarizations_are_not_mistaken_for_the_saved_ones():
+    """transmitterReceiverPolarisation is what was asked for, not what landed on disk --
+    a legacy file carries ['VV','VH'] there while holding only VH."""
+    resolved = es.get_band_order_from_meta(
+        {"transmitterReceiverPolarisation": ["VV", "VH"], "saved_polarization": "VH"}
+    )
+    assert resolved == ["VH"]
+
+
+# ---------------------------------------------------------------------------
+# get_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_get_metadata_records_band_order_for_s1(s1_site):
+    root, meta_dir = s1_site
+    write_meta(str(meta_dir), "2023-12-03-19-15-49_S1_site.txt", DUAL_POL_META)
+
+    metadata = read_s1_metadata(root)
+
+    assert metadata["S1"]["band_order"] == [["VV", "VH"]]
+
+
+def test_band_order_stays_index_aligned_on_a_mixed_site(s1_site):
+    """A legacy VH-only scene sitting next to a new dual-pol one. band_order[i] must
+    stay safe to index alongside filenames[i]."""
+    root, meta_dir = s1_site
+    write_meta(str(meta_dir), "2023-12-03-19-15-49_S1_site.txt", DUAL_POL_META)
+    write_meta(str(meta_dir), "2024-08-02-08-39-41_S1_site_VH.txt", LEGACY_META)
+
+    s1 = read_s1_metadata(root)["S1"]
+
+    assert len(s1["band_order"]) == len(s1["filenames"]) == 2
+    assert s1["band_order"] == [["VV", "VH"], ["VH"]]
+
+
+def test_optical_satellites_do_not_gain_a_band_order_key(tmp_path):
+    meta_dir = tmp_path / "site" / "L8" / "meta"
+    meta_dir.mkdir(parents=True)
+    write_meta(
+        str(meta_dir),
+        "2023-12-03-19-15-49_L8_site.txt",
+        "filename\t2023-12-03-19-15-49_L8_site_ms.tif\nepsg\t32756\n",
+    )
+
+    metadata = es.get_metadata(
+        {
+            "filepath": str(tmp_path),
+            "sitename": "site",
+            "sat_list": ["L8"],
+            "dates": ["2020-01-01", "2030-01-01"],
+        }
+    )
+
+    assert "band_order" not in metadata["L8"]

--- a/tests/test_sar_coastsat_workflow.py
+++ b/tests/test_sar_coastsat_workflow.py
@@ -1,0 +1,260 @@
+"""Tests for the CoastSat (classic) Sentinel-1 workflow.
+
+That workflow hands everything to ``SDS_shoreline.extract_shorelines``, which segments S1
+with coastsat's trained ONNX model. coastsat reads three settings out of the dict CoastSeg
+builds for it, so these tests pin two things:
+
+1. the settings actually survive CoastSeg's allowlists and reach coastsat, and
+2. ``sar_model_path`` is stored relative to the CoastSeg directory, never absolute, so a
+   config.json stays usable on another machine.
+"""
+
+import os
+
+import pytest
+
+from coastseg import common, coastseg_map, sar_model
+from coastseg import extracted_shoreline as es
+
+
+SAR_KEYS = ("sar_segmentation", "sar_water_threshold", "sar_model_path")
+
+
+@pytest.fixture
+def based_at(monkeypatch, tmp_path):
+    """Point core_utilities.get_base_dir at tmp_path for both path helpers."""
+    monkeypatch.setattr(common.core_utilities, "get_base_dir", lambda *a, **k: tmp_path)
+    return tmp_path
+
+
+def shoreline_settings(settings):
+    """Build the dict CoastSeg hands to SDS_shoreline.extract_shorelines."""
+    return es.Extracted_Shoreline().create_shoreline_settings(
+        settings,
+        {"roi_id": "abc1", "sitename": "site", "filepath": "data"},
+        reference_shoreline={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# The settings reach coastsat
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_is_the_model_not_otsu():
+    """The trained segmenter is the default path for Sentinel-1."""
+    settings = coastseg_map.CoastSeg_Map(create_map=False).set_settings()
+
+    assert settings["sar_segmentation"] == "model"
+    assert settings["sar_water_threshold"] == 0.5
+    assert settings["sar_model_path"] == ""
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("sar_segmentation", "otsu"),
+        ("sar_water_threshold", 0.8),
+    ],
+)
+def test_create_shoreline_settings_passes_the_sar_keys_to_coastsat(key, value):
+    """coastsat reads these straight out of the dict; the allowlist used to drop them."""
+    settings = coastseg_map.CoastSeg_Map(create_map=False).set_settings(**{key: value})
+
+    assert shoreline_settings(settings)[key] == value
+
+
+def test_empty_sar_model_path_survives_rather_than_being_stripped(monkeypatch):
+    """'' is meaningful: it tells coastsat to resolve and download its own model.
+
+    It must reach coastsat rather than being dropped by the SHORELINE_KEYS allowlist.
+    With no model in CoastSeg's models/ directory it stays '' -- see
+    test_an_unset_path_points_coastsat_at_a_manually_downloaded_model for the case
+    where one is there.
+    """
+    monkeypatch.setattr(sar_model, "find_local_sar_model", lambda: "")
+    settings = coastseg_map.CoastSeg_Map(create_map=False).set_settings()
+
+    assert shoreline_settings(settings)["sar_model_path"] == ""
+
+
+def test_an_unset_path_points_coastsat_at_a_manually_downloaded_model(monkeypatch):
+    """A user who downloads the model by hand into models/SAR_segmentation_model
+    expects both workflows to use it. The zoo path reads that directory directly, but
+    coastsat looks only in its own pooch cache -- so without this the same 130 MB would
+    be downloaded a second time for the coastsat run."""
+    manual = r"C:\CoastSeg\models\SAR_segmentation_model\SAR_3_band_model.onnx"
+    monkeypatch.setattr(sar_model, "find_local_sar_model", lambda: manual)
+    settings = coastseg_map.CoastSeg_Map(create_map=False).set_settings()
+
+    assert shoreline_settings(settings)["sar_model_path"] == manual
+
+
+def test_an_explicit_path_is_not_overridden_by_the_local_model(monkeypatch):
+    """An explicit choice always wins; the models/ directory is only a fallback."""
+    monkeypatch.setattr(
+        sar_model, "find_local_sar_model", lambda: r"C:\CoastSeg\models\local.onnx"
+    )
+    settings = coastseg_map.CoastSeg_Map(create_map=False).set_settings(
+        sar_model_path="models/retrained.onnx"
+    )
+
+    handed_to_coastsat = shoreline_settings(settings)["sar_model_path"]
+    assert handed_to_coastsat.endswith(os.path.join("models", "retrained.onnx"))
+    assert "local.onnx" not in handed_to_coastsat
+
+
+def test_settings_absent_from_the_input_are_simply_absent():
+    """A settings dict predating these keys must not gain them with junk values."""
+    result = shoreline_settings({"output_epsg": 4326, "min_beach_area": 100})
+
+    assert not any(key in result for key in SAR_KEYS)
+
+
+def test_the_override_reaches_extract_shorelines(monkeypatch, tmp_path):
+    """End to end through Extracted_Shoreline.extract_shorelines.
+
+    A unit test on SHORELINE_KEYS alone would not catch a later refactor that rebuilds
+    the settings dict somewhere else, so capture what coastsat is actually handed.
+    """
+    captured = {}
+
+    def fake_extract_shorelines(metadata, settings, **kwargs):
+        captured.update(settings)
+        return {}
+
+    monkeypatch.setattr(
+        es.SDS_shoreline, "extract_shorelines", fake_extract_shorelines
+    )
+    monkeypatch.setattr(es, "get_metadata", lambda *a, **k: {"S1": {"filenames": ["x"]}})
+    monkeypatch.setattr(es.common, "filter_metadata_with_dates", lambda m, *a, **k: m)
+    monkeypatch.setattr(es, "get_reference_shoreline", lambda *a, **k: {})
+    monkeypatch.setattr(es.SDS_tools, "remove_duplicates", lambda output: output)
+    monkeypatch.setattr(es.SDS_tools, "remove_inaccurate_georef", lambda output, _: output)
+    monkeypatch.setattr(es, "get_data_folder", lambda *a, **k: str(tmp_path))
+
+    settings = coastseg_map.CoastSeg_Map(create_map=False).set_settings(
+        sar_segmentation="otsu", sar_water_threshold=0.75
+    )
+    es.Extracted_Shoreline().extract_shorelines(
+        shoreline_gdf=None,
+        roi_settings={
+            "roi_id": "abc1",
+            "sitename": "site",
+            "filepath": str(tmp_path),
+            "sat_list": ["S1"],
+            "dates": ["2023-01-01", "2024-01-01"],
+        },
+        settings=settings,
+    )
+
+    assert captured["sar_segmentation"] == "otsu"
+    assert captured["sar_water_threshold"] == 0.75
+
+
+def test_the_sar_keys_round_trip_through_load_settings(tmp_path):
+    written = {
+        "sar_segmentation": "otsu",
+        "sar_water_threshold": 0.7,
+        "sar_model_path": "models/retrained.onnx",
+    }
+    loaded = common.load_settings(new_settings=written)
+
+    assert {key: loaded[key] for key in SAR_KEYS} == written
+
+
+def test_the_sar_keys_round_trip_through_extract_roi_settings():
+    config = {
+        "roi_ids": ["abc1"],
+        "abc1": {
+            "sitename": "site",
+            "sat_list": ["S1"],
+            "sar_segmentation": "otsu",
+            "sar_water_threshold": 0.7,
+            "sar_model_path": "models/retrained.onnx",
+        },
+    }
+    roi_settings = common.extract_roi_settings(config)
+
+    assert roi_settings["abc1"]["sar_segmentation"] == "otsu"
+    assert roi_settings["abc1"]["sar_water_threshold"] == 0.7
+    assert roi_settings["abc1"]["sar_model_path"] == "models/retrained.onnx"
+
+
+# ---------------------------------------------------------------------------
+# sar_model_path is stored relative, resolved absolute
+# ---------------------------------------------------------------------------
+
+
+def test_empty_path_stays_empty_through_both_helpers(based_at):
+    """coastsat falls back to its packaged model on a falsy value."""
+    assert common.relativize_sar_model_path("") == ""
+    assert common.resolve_sar_model_path("") == ""
+
+
+def test_an_absolute_path_inside_the_tree_is_stored_relative(based_at):
+    absolute = str(based_at / "models" / "retrained.onnx")
+
+    stored = common.relativize_sar_model_path(absolute)
+
+    assert stored == "models/retrained.onnx"  # POSIX, so a Windows config loads on Linux
+    assert not os.path.isabs(stored)
+    assert os.path.normcase(common.resolve_sar_model_path(stored)) == os.path.normcase(
+        absolute
+    )
+
+
+def test_relativizing_is_idempotent(based_at):
+    stored = common.relativize_sar_model_path(str(based_at / "models" / "m.onnx"))
+
+    assert common.relativize_sar_model_path(stored) == stored
+
+
+def test_a_relative_path_resolves_against_the_base_dir_not_the_cwd(
+    based_at, monkeypatch, tmp_path
+):
+    """coastsat runs os.path.abspath on whatever it is given, which would resolve
+    against wherever the notebook happens to be running."""
+    elsewhere = tmp_path / "somewhere_else"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    resolved = common.resolve_sar_model_path("models/retrained.onnx")
+
+    assert os.path.normcase(resolved) == os.path.normcase(
+        str(based_at / "models" / "retrained.onnx")
+    )
+    assert os.path.normcase(str(elsewhere)) not in os.path.normcase(resolved)
+
+
+def test_a_path_outside_the_tree_is_kept_verbatim_and_warns(based_at, tmp_path, caplog):
+    outside = tmp_path.parent / "outside_the_repo" / "m.onnx"
+
+    with caplog.at_level("WARNING"):
+        stored = common.relativize_sar_model_path(str(outside))
+
+    assert stored == outside.as_posix()
+    assert "cannot be stored relatively" in caplog.text
+
+
+def test_set_settings_never_persists_an_absolute_path(based_at):
+    absolute = str(based_at / "models" / "retrained.onnx")
+
+    settings = coastseg_map.CoastSeg_Map(create_map=False).set_settings(
+        sar_model_path=absolute
+    )
+
+    assert settings["sar_model_path"] == "models/retrained.onnx"
+
+
+def test_coastsat_receives_the_absolute_path(based_at):
+    """Stored relative for portability, handed to coastsat absolute so it can be opened."""
+    absolute = based_at / "models" / "retrained.onnx"
+    settings = coastseg_map.CoastSeg_Map(create_map=False).set_settings(
+        sar_model_path=str(absolute)
+    )
+
+    handed_to_coastsat = shoreline_settings(settings)["sar_model_path"]
+
+    assert os.path.isabs(handed_to_coastsat)
+    assert os.path.normcase(handed_to_coastsat) == os.path.normcase(str(absolute))

--- a/tests/test_sar_download.py
+++ b/tests/test_sar_download.py
@@ -1,0 +1,207 @@
+"""Tests for the Sentinel-1 download and the resume of a partly-downloaded site.
+
+The download itself lives in coastsat; CoastSeg only builds the ``inputs`` block and calls
+``SDS_download.retrieve_images``. These tests pin that boundary:
+
+1. an S1 download asks for both polarizations, and an explicit choice is not overwritten,
+2. a site missing a polarization reaches coastsat untouched -- CoastSeg does not intercept
+   or warn, because coastsat backfills it during this same call and reports that itself,
+3. re-running such a site re-queues the incomplete scene and backfills VV in place --
+   same sitename, no duplicate.
+
+Earth Engine is never contacted: ``retrieve_images`` is replaced by a capturing stub.
+"""
+
+import os
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Polygon
+
+from coastsat import SDS_download
+
+from coastseg import coastseg_map
+from coastseg import extracted_shoreline as es
+
+
+@pytest.fixture
+def captured_downloads(monkeypatch):
+    """Replace coastsat's downloader with a stub that records what it was handed."""
+    calls = []
+    monkeypatch.setattr(
+        SDS_download,
+        "retrieve_images",
+        lambda inputs, **kwargs: calls.append(inputs),
+    )
+    return calls
+
+
+@pytest.fixture
+def one_roi_gdf():
+    """A single ROI, the shape CoastSeg_Map.download_imagery expects."""
+    return gpd.GeoDataFrame(
+        {"id": ["roi1"]},
+        geometry=[
+            Polygon(
+                [
+                    (-122.50, 37.70),
+                    (-122.40, 37.70),
+                    (-122.40, 37.80),
+                    (-122.50, 37.80),
+                ]
+            )
+        ],
+        crs="EPSG:4326",
+    )
+
+
+def download_one_roi(monkeypatch, roi_gdf, destination, **settings):
+    """Run CoastSeg_Map.download_imagery for one S1 ROI without writing a config."""
+    coastseg_object = coastseg_map.CoastSeg_Map(create_map=False)
+    monkeypatch.setattr(coastseg_object, "save_config", lambda *a, **k: None)
+    resolved = coastseg_object.set_settings(
+        sat_list=["S1"],
+        dates=["2023-01-01", "2023-06-01"],
+        landsat_collection="C02",
+        **settings,
+    )
+    coastseg_object.download_imagery(
+        rois=roi_gdf,
+        settings=resolved,
+        selected_ids={"roi1"},
+        file_path=str(destination),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Both polarizations are requested
+# ---------------------------------------------------------------------------
+
+
+def test_download_imagery_asks_coastsat_for_both_polarizations(
+    monkeypatch, tmp_path, one_roi_gdf, captured_downloads
+):
+    """The SAR segmentation model needs VV, VH and their difference.
+
+    A download that quietly asks for one polarization produces a site the model cannot
+    read, and the failure only shows up much later at extraction time.
+    """
+    download_one_roi(monkeypatch, one_roi_gdf, tmp_path)
+
+    assert len(captured_downloads) == 1
+    inputs = captured_downloads[0]
+    assert inputs["sat_list"] == ["S1"]
+    assert inputs["sentinel_1_properties"]["transmitterReceiverPolarisation"] == [
+        "VV",
+        "VH",
+    ]
+
+
+def test_an_explicit_polarization_choice_is_not_overwritten(
+    monkeypatch, tmp_path, one_roi_gdf, captured_downloads
+):
+    """A user asking for VV only must not have the VV+VH default put back."""
+    download_one_roi(
+        monkeypatch,
+        one_roi_gdf,
+        tmp_path,
+        sentinel_1_properties={
+            "transmitterReceiverPolarisation": ["VV"],
+            "instrumentMode": "IW",
+        },
+    )
+
+    inputs = captured_downloads[0]
+    assert inputs["sentinel_1_properties"]["transmitterReceiverPolarisation"] == ["VV"]
+
+
+# ---------------------------------------------------------------------------
+# An incomplete site reaches coastsat intact
+# ---------------------------------------------------------------------------
+
+
+def test_a_vh_only_site_is_handed_straight_to_coastsat(
+    sar_legacy_site_with_meta, captured_downloads
+):
+    """A site missing a polarization must not be intercepted on the way to the download.
+
+    CoastSeg used to warn here first. It no longer does: coastsat re-queues the
+    incomplete scenes and backfills them in place during this very call, and reports
+    that itself in terms of scenes rather than polarization folders. Anything CoastSeg
+    printed beforehand would have told the user to re-run the download they had already
+    started.
+    """
+    inputs = sar_legacy_site_with_meta["inputs"]
+
+    coastseg_map.CoastSeg_Map(create_map=False).retrieve_images_for_rois([inputs], {})
+
+    assert len(captured_downloads) == 1
+    assert captured_downloads[0] is inputs
+
+
+def test_the_incomplete_site_is_left_on_disk_untouched(
+    sar_legacy_site_with_meta, captured_downloads
+):
+    """Nothing on the way to the download may delete the bands already downloaded.
+
+    The backfill overwrites scenes in place under the same sitename, so the VH already
+    on disk has to still be there when coastsat takes over.
+    """
+    coastseg_map.CoastSeg_Map(create_map=False).retrieve_images_for_rois(
+        [sar_legacy_site_with_meta["inputs"]], {}
+    )
+
+    assert os.path.isfile(sar_legacy_site_with_meta["vh"])
+    assert os.path.isfile(sar_legacy_site_with_meta["meta"])
+
+
+# ---------------------------------------------------------------------------
+# Resuming a VH-only download
+# ---------------------------------------------------------------------------
+
+
+def test_a_vh_only_scene_is_re_queued_for_download(sar_legacy_site_with_meta):
+    """coastsat must not report the scene as already downloaded just because the date is
+    on disk -- that is what left legacy sites single-polarization forever."""
+    inputs = sar_legacy_site_with_meta["inputs"]
+    metadata = es.get_metadata(inputs)
+
+    assert metadata["S1"]["band_order"] == [["VH"]]
+
+    incomplete = SDS_download.get_incomplete_sar_dates(
+        inputs, metadata["S1"], ["VV", "VH"]
+    )
+
+    assert len(incomplete) == 1
+
+
+def test_backfilling_vv_clears_the_incomplete_scene(sar_legacy_site_with_meta):
+    """Once VV lands next to VH the scene is complete and must not be fetched again."""
+    inputs = sar_legacy_site_with_meta["inputs"]
+    sar_legacy_site_with_meta["add_vv"]()
+    metadata = es.get_metadata(inputs)
+
+    incomplete = SDS_download.get_incomplete_sar_dates(
+        inputs, metadata["S1"], ["VV", "VH"]
+    )
+
+    assert incomplete == set()
+
+
+def test_the_resumed_site_keeps_its_sitename_and_gains_no_duplicate(
+    sar_legacy_site_with_meta,
+):
+    """The backfill overwrites the scene in place: one file per polarization, no _dup
+    suffix, and both polarizations present."""
+    sar_legacy_site_with_meta["add_vv"]()
+
+    s1_root = os.path.join(sar_legacy_site_with_meta["site"], "S1")
+    for polarization in ("VV", "VH"):
+        tifs = [
+            name
+            for name in os.listdir(os.path.join(s1_root, polarization))
+            if name.endswith(".tif")
+        ]
+        assert len(tifs) == 1
+        assert "_dup" not in tifs[0]
+        assert tifs[0].startswith(sar_legacy_site_with_meta["scene_date"])

--- a/tests/test_sar_extraction_workflows.py
+++ b/tests/test_sar_extraction_workflows.py
@@ -1,0 +1,366 @@
+"""Tests that Sentinel-1 shorelines can be extracted in both workflows.
+
+The two workflows reach segmentation by different routes:
+
+* **zoo** -- ``Zoo_Model.run_model`` segments first and writes ``*_res.npz``, then
+  ``extract_shorelines_with_dask`` traces contours from the class labels. The SAR branch
+  runs onnxruntime in-process; the optical branch shells out to the TensorFlow
+  environment. Picking the wrong one is silent until it fails much later.
+* **coastsat** -- ``Extracted_Shoreline.extract_shorelines`` hands everything to
+  ``SDS_shoreline.extract_shorelines``, which segments S1 itself.
+
+Nothing here loads the 130 MB ONNX model, launches the TensorFlow subprocess, or reads a
+real scene: the two segmenters and coastsat's extractor are replaced by capturing stubs.
+"""
+
+import numpy as np
+import pytest
+
+from coastseg import extracted_shoreline as es
+from coastseg import sar_model, zoo_model
+
+
+# ---------------------------------------------------------------------------
+# Zoo workflow: which segmenter runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def routed_segmenters(monkeypatch):
+    """Stub both segmentation backends and record which one was called."""
+    calls = {}
+
+    def fake_sar_segmentation(**kwargs):
+        calls["sar"] = kwargs
+        return {"written_npz": 1, "total_images": 1, "failures": []}
+
+    def fake_external_segmentation(**kwargs):
+        calls["external"] = kwargs
+
+    monkeypatch.setattr(sar_model, "run_sar_segmentation", fake_sar_segmentation)
+    monkeypatch.setattr(
+        zoo_model, "run_segmentation_in_external_env", fake_external_segmentation
+    )
+    return calls
+
+
+def model_directory(tmp_path, name, weights):
+    """A model directory identified only by the extension of the file inside it."""
+    directory = tmp_path / name
+    directory.mkdir()
+    (directory / weights).write_bytes(b"")
+    return str(directory)
+
+
+def run_model(monkeypatch, directory, roi_directory="roi"):
+    """Invoke Zoo_Model.run_model against a directory, skipping model resolution."""
+    model = zoo_model.Zoo_Model()
+    monkeypatch.setattr(model, "resolve_model_directory", lambda setting: directory)
+    model.run_model(
+        {}, "sample_directory", "session_directory", roi_directory=roi_directory
+    )
+
+
+def test_a_sar_model_directory_routes_to_the_onnx_driver(
+    monkeypatch, tmp_path, routed_segmenters
+):
+    """A directory holding an .onnx is a SAR model and runs in-process."""
+    directory = model_directory(tmp_path, "sar_model_dir", "SAR_3_band_model.onnx")
+
+    run_model(monkeypatch, directory, roi_directory="roi_data")
+
+    assert "external" not in routed_segmenters
+    assert routed_segmenters["sar"]["roi_directory"] == "roi_data"
+    assert routed_segmenters["sar"]["model_directory"] == directory
+
+
+def test_an_optical_model_directory_routes_to_the_tensorflow_env(
+    monkeypatch, tmp_path, routed_segmenters
+):
+    """The complement: no .onnx means the SegFormer path in the separate environment.
+
+    Together with the test above this pins is_sar_model_directory as the whole
+    discriminator -- there is no img_type flag consulted here.
+    """
+    directory = model_directory(tmp_path, "segformer_dir", "weights.h5")
+
+    run_model(monkeypatch, directory)
+
+    assert "sar" not in routed_segmenters
+    assert routed_segmenters["external"]["model_path"] == directory
+
+
+def test_the_sar_path_requires_the_roi_directory(
+    monkeypatch, tmp_path, routed_segmenters
+):
+    """The SAR model reads the S1 GeoTIFFs, not the jpg previews the optical path uses,
+    so a missing ROI directory has to fail loudly rather than segment nothing."""
+    directory = model_directory(tmp_path, "sar_model_dir", "model.onnx")
+
+    with pytest.raises(ValueError, match="ROI directory"):
+        run_model(monkeypatch, directory, roi_directory="")
+
+    assert routed_segmenters == {}
+
+
+# ---------------------------------------------------------------------------
+# Zoo workflow: reaching the SAR model without naming its directory
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def designated_sar_directory(monkeypatch, tmp_path):
+    """Point CoastSeg's designated SAR directory somewhere empty and unwritten.
+
+    Absent, not merely empty: the model is 130 MB and downloaded on first use, so a
+    fresh clone has no such directory at all.
+    """
+    directory = tmp_path / "models" / sar_model.DEFAULT_SAR_MODEL_DIRNAME
+    monkeypatch.setattr(
+        zoo_model.sar_model, "get_sar_model_directory", lambda: str(directory)
+    )
+    monkeypatch.setattr(
+        zoo_model.sar_model, "load_sar_model_spec", lambda directory: None
+    )
+    return directory
+
+
+def test_selecting_sar_without_a_local_path_uses_the_designated_directory(
+    monkeypatch, designated_sar_directory
+):
+    """``img_type='SAR'`` alone is enough to reach the model.
+
+    'SAR' names an image type, not a Zoo model id, so falling through to the Zoo
+    downloader looks ``model_type`` up on Zenodo and fails with a 404 -- an error that
+    says nothing about SAR. The UI never sees this because it fills in
+    'local_model_path' itself; a script that sets only 'img_type' does.
+    """
+
+    def fail(*args, **kwargs):  # pragma: no cover - only runs if the branch is wrong
+        raise AssertionError("SAR must not be resolved through the Zoo downloader")
+
+    model = zoo_model.Zoo_Model()
+    monkeypatch.setattr(model, "ensure_model_downloaded", fail)
+
+    resolved = model.resolve_model_directory(
+        {"img_type": "SAR", "model_type": "SAR_segmentation_model"}
+    )
+
+    assert resolved == str(designated_sar_directory)
+
+
+def test_the_sar_directory_resolves_before_the_model_is_downloaded(
+    designated_sar_directory,
+):
+    """An absent SAR directory is the fresh-clone state, not a configuration error.
+
+    ``is_sar_model_directory`` deliberately answers True here so the first run routes
+    to the ONNX path and downloads the model. Rejecting the path for not existing yet
+    would make that download unreachable.
+    """
+    assert not designated_sar_directory.exists()
+
+    model = zoo_model.Zoo_Model()
+    resolved = model.resolve_model_directory(
+        {"img_type": "SAR", "local_model_path": str(designated_sar_directory)}
+    )
+
+    assert resolved == str(designated_sar_directory)
+
+
+def test_a_missing_optical_model_path_is_still_an_error(tmp_path):
+    """The tolerance above is scoped to SAR; a typo'd optical path must still raise."""
+    missing = tmp_path / "not_a_real_model_directory"
+
+    model = zoo_model.Zoo_Model()
+    with pytest.raises(FileNotFoundError, match="local_model_path"):
+        model.resolve_model_directory(
+            {"img_type": "RGB", "local_model_path": str(missing)}
+        )
+
+
+def test_a_missing_non_sar_directory_is_an_error_even_when_sar_is_selected(tmp_path):
+    """Selecting SAR does not excuse a path that is not a SAR directory at all."""
+    missing = tmp_path / "some_other_model"
+
+    model = zoo_model.Zoo_Model()
+    with pytest.raises(FileNotFoundError, match="local_model_path"):
+        model.resolve_model_directory(
+            {"img_type": "SAR", "local_model_path": str(missing)}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Zoo workflow: where the class mapping comes from
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sar_spec(monkeypatch):
+    """Stub the ONNX spec so no 130 MB model is loaded."""
+
+    class Spec:
+        classes = {0: "land", 1: "water"}
+
+    monkeypatch.setattr(sar_model, "load_sar_model_spec", lambda directory: Spec())
+    return Spec
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        pytest.param(["SAR_3_band_model.onnx"], id="downloaded-onnx-only"),
+        pytest.param(["my_retrained.onnx"], id="user-supplied-onnx"),
+    ],
+)
+def test_a_sar_model_directory_takes_its_classes_from_the_onnx(
+    monkeypatch, tmp_path, sar_spec, contents
+):
+    """A SAR model directory has no ``*modelcard.json``, and must not be given the
+    optical default mapping because of it.
+
+    The model is fetched as a bare ``.onnx`` into coastsat's cache, and a user supplying
+    their own drops in one file, so neither case ever produces a model card. Falling back
+    to the 4-class Zoo mapping sets ``water_class_indices`` to ``[0, 1]``, which on SAR's
+    ``{0: land, 1: water}`` labels marks *every* pixel as water: no land/water boundary,
+    no contour, and extraction raises ``No_Extracted_Shoreline`` while segmentation looks
+    perfectly healthy.
+    """
+    directory = tmp_path / "SAR_segmentation_model"
+    directory.mkdir()
+    for name in contents:
+        (directory / name).write_bytes(b"")
+    assert not list(directory.glob("*modelcard.json"))
+
+    model = zoo_model.Zoo_Model()
+    info = model.load_model_info({"local_model_path": str(directory)})
+
+    assert info.class_mapping == {0: "land", 1: "water"}
+    assert info.water_class_indices == [1]
+
+
+def test_an_optical_model_directory_still_reads_its_model_card(monkeypatch, tmp_path):
+    """The SAR branch must not intercept a directory holding ordinary Zoo weights."""
+    directory = tmp_path / "segformer_RGB_4class"
+    directory.mkdir()
+    (directory / "weights.h5").write_bytes(b"")
+
+    def fail(directory):  # pragma: no cover - only runs if the branch is wrong
+        raise AssertionError("the optical path must not load a SAR spec")
+
+    monkeypatch.setattr(sar_model, "load_sar_model_spec", fail)
+
+    model = zoo_model.Zoo_Model()
+    info = model.load_model_info({"local_model_path": str(directory)})
+
+    # No model card either, so this is the documented optical default.
+    assert info.water_class_indices == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# Zoo workflow: extraction from a segmented session
+# ---------------------------------------------------------------------------
+
+
+def test_the_zoo_session_tags_s1_shorelines_as_sar_model(monkeypatch, tmp_path):
+    """S1 goes through extraction and is recorded as segmented by the SAR model.
+
+    ``segmentation_method`` is what later tells a threshold filter to leave these
+    shorelines alone, and ``combine_satellite_data`` builds its column list from the keys
+    present, so a column missing on one satellite desynchronizes the merged lists.
+    """
+    processed = []
+
+    def fake_process_satellite(satname, settings, metadata, session_path, *args, **kwargs):
+        processed.append(satname)
+        return {
+            satname: {
+                "dates": ["2023-05-01-04-26-29"],
+                "shorelines": [np.array([[0.0, 0.0], [1.0, 1.0]])],
+                "filename": ["2023-05-01-04-26-29_S1_site_VV.tif"],
+                "cloud_cover": [0.0],
+                "geoaccuracy": [1.0],
+                "idx": [0],
+                "satname": [satname],
+                "segmentation_method": [es.get_segmentation_method(satname)],
+            }
+        }
+
+    monkeypatch.setattr(es, "process_satellite", fake_process_satellite)
+
+    output = es.extract_shorelines_with_dask(
+        session_path=str(tmp_path),
+        metadata={"S1": {"filenames": ["a"], "dates": ["2023-05-01-04-26-29"]}},
+        settings={"inputs": {"sitename": "site", "filepath": str(tmp_path)}},
+        save_location=str(tmp_path),
+    )
+
+    assert processed == ["S1"]
+    assert output["satname"] == ["S1"]
+    assert output["segmentation_method"] == ["sar_model"]
+    assert len(output["segmentation_method"]) == len(output["shorelines"])
+
+
+# ---------------------------------------------------------------------------
+# CoastSat workflow
+# ---------------------------------------------------------------------------
+
+
+def test_the_coastsat_workflow_hands_coastsat_an_s1_only_run(monkeypatch, tmp_path):
+    """coastsat decides to segment with its SAR model from the run it is handed.
+
+    ``sat_list`` and the metadata keys are what select the S1 branch inside
+    ``SDS_shoreline.extract_shorelines``; an ROI that loses either of them silently falls
+    through to the optical path.
+    """
+    captured = {}
+
+    def fake_extract_shorelines(metadata, settings, **kwargs):
+        captured["metadata"] = metadata
+        captured["settings"] = settings
+        return {}
+
+    monkeypatch.setattr(es.SDS_shoreline, "extract_shorelines", fake_extract_shorelines)
+    monkeypatch.setattr(
+        es, "get_metadata", lambda *a, **k: {"S1": {"filenames": ["scene_VV.tif"]}}
+    )
+    monkeypatch.setattr(es.common, "filter_metadata_with_dates", lambda m, *a, **k: m)
+    monkeypatch.setattr(es, "get_reference_shoreline", lambda *a, **k: {})
+    monkeypatch.setattr(es.SDS_tools, "remove_duplicates", lambda output: output)
+    monkeypatch.setattr(
+        es.SDS_tools, "remove_inaccurate_georef", lambda output, _: output
+    )
+    monkeypatch.setattr(es, "get_data_folder", lambda *a, **k: str(tmp_path))
+
+    es.Extracted_Shoreline().extract_shorelines(
+        shoreline_gdf=None,
+        roi_settings={
+            "roi_id": "abc1",
+            "sitename": "site",
+            "filepath": str(tmp_path),
+            "sat_list": ["S1"],
+            "dates": ["2023-01-01", "2024-01-01"],
+        },
+        settings={"output_epsg": 4326, "min_beach_area": 100},
+    )
+
+    assert list(captured["metadata"]) == ["S1"]
+    assert captured["settings"]["inputs"]["sat_list"] == ["S1"]
+
+
+def test_a_sar_shoreline_is_exempt_from_the_mndwi_threshold_filter():
+    """A SAR shoreline carries no MNDWI threshold, so it must not be filtered on one.
+
+    ``MNDWI_threshold`` holds a different quantity per segmentation method: an MNDWI value
+    for the optical contour path, but NaN when a model mapped the shoreline. Comparing NaN
+    to an MNDWI range fails every time and would delete every SAR shoreline.
+    """
+    output = {
+        "shorelines": [np.array([[0.0, 0.0]]), np.array([[1.0, 1.0]])],
+        "MNDWI_threshold": [float("nan"), 0.1],
+        "segmentation_method": ["sar_model", "mndwi"],
+    }
+
+    applies = es.threshold_filter_applies(output)
+
+    assert list(applies) == [False, True]

--- a/tests/test_sar_model.py
+++ b/tests/test_sar_model.py
@@ -1,0 +1,411 @@
+"""Unit tests for the Sentinel-1 ONNX segmentation preprocessing contract.
+
+Getting any preprocessing step wrong does not crash -- it silently degrades or destroys
+accuracy -- so each step of the documented pipeline is pinned here.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from coastseg import sar_model
+
+SAR_MODEL_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "models",
+    "SAR_segmentation_model",
+)
+
+requires_model = pytest.mark.skipif(
+    not os.path.isdir(SAR_MODEL_DIR) or not any(
+        name.endswith(".onnx") for name in os.listdir(SAR_MODEL_DIR)
+    ),
+    reason="the SAR ONNX model is not present in models/SAR_segmentation_model",
+)
+
+
+# ---------------------------------------------------------------------------
+# Model spec
+# ---------------------------------------------------------------------------
+
+
+@requires_model
+def test_load_spec_reads_metadata_props():
+    """Every constant comes from the model file, not from hardcoded values."""
+    spec = sar_model.load_sar_model_spec(SAR_MODEL_DIR)
+
+    assert spec.channel_order == ("VV", "VH", "VV-VH")
+    assert np.allclose(spec.mean, [-12.59, -20.26, 10.5465])
+    assert np.allclose(spec.std, [5.26, 5.91, 7.6855])
+    assert spec.output_stride == 32
+    assert spec.nodata == 255
+    assert spec.classes == {0: "land", 1: "water"}
+    assert spec.input_name == "image"
+    assert spec.prob_output == "water_prob"
+    assert spec.input_scale == "dB"
+    assert spec.speckle_filter["type"] == "none"
+
+
+# The exported model exposes both of these, so which one carries P(water) is a real
+# choice, not a hypothetical one. Thresholding logits at 0.5 does not raise -- it just
+# maps the wrong shoreline.
+BOTH_OUTPUTS = ["logits", "water_prob"]
+
+
+def test_prob_output_prefers_the_named_water_probability():
+    assert (
+        sar_model._resolve_prob_output(BOTH_OUTPUTS, BOTH_OUTPUTS, "m.onnx")
+        == "water_prob"
+    )
+
+
+def test_prob_output_is_not_guessed_by_position():
+    """'water_prob' wins wherever it sits, so export order cannot change the result."""
+    reordered = ["water_prob", "logits"]
+
+    assert (
+        sar_model._resolve_prob_output(reordered, reordered, "m.onnx") == "water_prob"
+    )
+
+
+def test_ambiguous_outputs_raise_instead_of_picking_one():
+    """Falling back to the last output would silently threshold logits at 0.5."""
+    names = ["logits", "features"]
+
+    with pytest.raises(sar_model.SarModelError, match="water_prob"):
+        sar_model._resolve_prob_output(names, names, "retrained.onnx")
+
+
+def test_a_single_output_is_used_but_says_so(caplog):
+    """One output is unambiguous; the run continues, but not silently."""
+    with caplog.at_level("WARNING"):
+        chosen = sar_model._resolve_prob_output(["prob"], ["prob"], "m.onnx")
+
+    assert chosen == "prob"
+    assert any("water_prob" in record.message for record in caplog.records)
+
+
+def test_metadata_naming_an_output_the_graph_lacks_raises():
+    """Otherwise session.run fails later with an opaque onnxruntime error."""
+    with pytest.raises(sar_model.SarModelError, match="graph exposes"):
+        sar_model._resolve_prob_output(
+            ["water_prob"], ["logits", "probability"], "m.onnx"
+        )
+
+
+def test_water_class_indices_is_derived_from_class_names(sar_model_spec_stub):
+    # This model's water class is 1, the inverse of the SegFormer convention.
+    assert sar_model_spec_stub.water_class_indices == [1]
+
+
+def test_required_polarizations_expands_difference_channels(sar_model_spec_stub):
+    """A VV-VH channel contributes both operands, not a literal 'VV-VH' band."""
+    assert sar_model_spec_stub.required_polarizations == ("VV", "VH")
+
+
+def test_is_sar_model_directory(tmp_path, sar_scene_tifs):
+    assert not sar_model.is_sar_model_directory("")
+    assert not sar_model.is_sar_model_directory(str(tmp_path))
+    (tmp_path / "some_model.onnx").write_bytes(b"")
+    assert sar_model.is_sar_model_directory(str(tmp_path))
+
+
+def test_the_designated_directory_routes_as_sar_while_still_empty(tmp_path):
+    """The model is downloaded on first use, so the designated directory is empty (or
+    absent) until then. If routing depended on the file being there, the first SAR run
+    on a fresh clone would be sent down the TensorFlow path instead."""
+    designated = tmp_path / sar_model.DEFAULT_SAR_MODEL_DIRNAME
+
+    assert sar_model.is_sar_model_directory(str(designated))  # does not exist yet
+    designated.mkdir()
+    assert sar_model.is_sar_model_directory(str(designated))  # exists but empty
+
+
+def test_find_sar_onnx_file_missing_raises_when_download_is_off(tmp_path):
+    with pytest.raises(FileNotFoundError, match="No .onnx file"):
+        sar_model.find_sar_onnx_file(str(tmp_path), download=False)
+
+
+# ---------------------------------------------------------------------------
+# Band stack (steps 1-7)
+# ---------------------------------------------------------------------------
+
+
+def test_difference_channel_uses_raw_db_before_any_fill(
+    sar_scene_tifs, sar_model_spec_stub
+):
+    """VV-VH must be derived before invalid pixels are filled.
+
+    Otherwise a fill value leaks into the subtraction and the third channel is wrong
+    wherever the scene has nodata.
+    """
+    stack, valid, _, _ = sar_model.build_sar_stack(
+        [sar_scene_tifs["vv"], sar_scene_tifs["vh"]], sar_model_spec_stub
+    )
+    assert stack.shape == (3, 50, 70)
+    assert np.allclose(stack[2], stack[0] - stack[1], equal_nan=True)
+
+
+def test_validity_mask_is_the_intersection_of_both_polarizations(
+    sar_scene_tifs, sar_model_spec_stub
+):
+    _, valid, _, _ = sar_model.build_sar_stack(
+        [sar_scene_tifs["vv"], sar_scene_tifs["vh"]], sar_model_spec_stub
+    )
+    height, width = sar_scene_tifs["shape"]
+    nodata_rows = sar_scene_tifs["nodata_rows"]
+    assert valid.shape == (height, width)
+    # VV's last rows are nodata, so they must be invalid in the combined mask
+    assert not valid[-nodata_rows:, :].any()
+    assert valid[: height - nodata_rows, :].all()
+
+
+def test_missing_polarization_raises(sar_site_vh_only, sar_model_spec_stub):
+    with pytest.raises(sar_model.MissingPolarizationError, match="VV"):
+        sar_model.build_sar_stack([sar_site_vh_only["vh"]], sar_model_spec_stub)
+
+
+def test_grid_mismatch_reprojects_onto_the_reference_grid(
+    sar_grid_mismatch_tifs, sar_model_spec_stub, caplog
+):
+    """A VH raster on a different grid is warped onto VV's grid, never the reverse."""
+    with caplog.at_level("WARNING"):
+        stack, valid, geotransform, _ = sar_model.build_sar_stack(
+            [sar_grid_mismatch_tifs["vv"], sar_grid_mismatch_tifs["vh"]],
+            sar_model_spec_stub,
+        )
+
+    assert stack.shape == (3,) + sar_grid_mismatch_tifs["shape"]
+    assert valid.shape == sar_grid_mismatch_tifs["shape"]
+    # georeferencing stays on the VV (reference) grid
+    assert geotransform[1] == 10.0
+    assert any("reprojecting" in record.message for record in caplog.records)
+
+
+def test_unsupported_speckle_filter_raises(sar_scene_tifs, sar_model_spec_stub):
+    """A model trained with a filter this module cannot apply must stop, not proceed."""
+    import dataclasses
+
+    spec = dataclasses.replace(
+        sar_model_spec_stub, speckle_filter={"type": "lee_sigma"}
+    )
+    with pytest.raises(sar_model.UnsupportedSpeckleFilterError, match="lee_sigma"):
+        sar_model.build_sar_stack(
+            [sar_scene_tifs["vv"], sar_scene_tifs["vh"]], spec
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fill / normalize / pad (steps 8-10)
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_pixels_normalize_to_exactly_zero(sar_model_spec_stub):
+    """Filling with the per-channel mean puts invalid pixels at a neutral 0."""
+    spec = sar_model_spec_stub
+    stack = np.zeros((3, 32, 32), dtype=np.float32)
+    stack[:, :, :] = 999.0  # an extreme outlier everywhere
+    valid = np.ones((32, 32), dtype=bool)
+    valid[0, 0] = False
+
+    tensor, _ = sar_model.preprocess(stack, valid, spec)
+    assert np.allclose(tensor[0, :, 0, 0], 0.0)
+
+
+def test_normalization_is_per_channel(sar_model_spec_stub):
+    spec = sar_model_spec_stub
+    stack = np.stack(
+        [
+            np.full((32, 32), -10.0, dtype=np.float32),
+            np.full((32, 32), -18.0, dtype=np.float32),
+            np.full((32, 32), 8.0, dtype=np.float32),
+        ]
+    )
+    valid = np.ones((32, 32), dtype=bool)
+
+    tensor, _ = sar_model.preprocess(stack, valid, spec)
+    expected = (np.array([-10.0, -18.0, 8.0], dtype=np.float32) - spec.mean) / spec.std
+    assert np.allclose(tensor[0, :, 5, 5], expected)
+
+
+def test_pads_bottom_right_to_a_multiple_of_the_output_stride(sar_model_spec_stub):
+    """50x70 becomes 64x96, padded with zeros on the bottom and right only."""
+    spec = sar_model_spec_stub
+    stack = np.ones((3, 50, 70), dtype=np.float32)
+    valid = np.ones((50, 70), dtype=bool)
+
+    tensor, original_shape = sar_model.preprocess(stack, valid, spec)
+
+    assert tensor.shape == (1, 3, 64, 96)
+    assert original_shape == (50, 70)
+    assert np.all(tensor[0, :, 50:, :] == 0.0)
+    assert np.all(tensor[0, :, :, 70:] == 0.0)
+    # nothing was padded on the top or left
+    assert not np.all(tensor[0, :, 0, 0] == 0.0)
+
+
+def test_already_aligned_shape_is_not_padded(sar_model_spec_stub):
+    stack = np.ones((3, 64, 32), dtype=np.float32)
+    valid = np.ones((64, 32), dtype=bool)
+    tensor, _ = sar_model.preprocess(stack, valid, sar_model_spec_stub)
+    assert tensor.shape == (1, 3, 64, 32)
+
+
+def test_oversized_scene_raises_instead_of_exhausting_memory(sar_model_spec_stub, monkeypatch):
+    monkeypatch.setattr(sar_model, "MAX_INPUT_PIXELS", 100)
+    stack = np.ones((3, 64, 64), dtype=np.float32)
+    valid = np.ones((64, 64), dtype=bool)
+    with pytest.raises(sar_model.SarModelError, match="pixel limit|above the"):
+        sar_model.preprocess(stack, valid, sar_model_spec_stub)
+
+
+# ---------------------------------------------------------------------------
+# Postprocessing
+# ---------------------------------------------------------------------------
+
+
+def test_postprocess_crops_padding_and_never_resizes(sar_model_spec_stub):
+    probability = np.zeros((1, 1, 64, 96), dtype=np.float32)
+    valid = np.ones((50, 70), dtype=bool)
+
+    label, cropped = sar_model.postprocess(probability, (50, 70), valid, sar_model_spec_stub)
+
+    assert label.shape == (50, 70)
+    assert cropped.shape == (50, 70)
+
+
+def test_threshold_boundary_is_inclusive(sar_model_spec_stub):
+    probability = np.array([[0.5, 0.4999, 0.9]], dtype=np.float32)
+    valid = np.ones((1, 3), dtype=bool)
+
+    label, _ = sar_model.postprocess(probability, (1, 3), valid, sar_model_spec_stub)
+
+    assert label.tolist() == [[1, 0, 1]]
+
+
+def test_nodata_is_stamped_onto_invalid_pixels(sar_model_spec_stub):
+    probability = np.full((1, 1, 32, 32), 0.9, dtype=np.float32)
+    valid = np.ones((32, 32), dtype=bool)
+    valid[0, :] = False
+
+    label, cropped = sar_model.postprocess(
+        probability, (32, 32), valid, sar_model_spec_stub
+    )
+
+    assert np.all(label[0, :] == 255)
+    assert np.all(label[1:, :] == 1)
+    assert np.all(np.isnan(cropped[0, :]))
+    assert not np.any(np.isnan(cropped[1:, :]))
+
+
+def test_labels_follow_the_model_class_indices_not_a_fixed_water_value(
+    sar_model_spec_stub,
+):
+    """A model free to declare {0: "water", 1: "land"} must not come out inverted.
+
+    Extraction decodes ``grey_label`` by testing equality against
+    ``model_info.water_class_indices``, which comes from these same class names. Writing
+    a fixed 1 for water would silently swap land and sea on such a model -- a plausible
+    looking shoreline on the wrong side of the beach.
+    """
+    import dataclasses
+
+    probability = np.array([[0.9, 0.1]], dtype=np.float32)
+    valid = np.ones((1, 2), dtype=bool)
+
+    reversed_spec = dataclasses.replace(
+        sar_model_spec_stub, classes={0: "water", 1: "land"}
+    )
+    label, _ = sar_model.postprocess(probability, (1, 2), valid, reversed_spec)
+
+    assert reversed_spec.water_class_indices == [0]
+    assert label.tolist() == [[0, 1]]  # water pixel carries the water class index
+
+
+def test_labels_still_use_1_for_water_on_the_conventional_mapping(sar_model_spec_stub):
+    """The shipped {0: land, 1: water} model keeps producing exactly what it did."""
+    probability = np.array([[0.9, 0.1]], dtype=np.float32)
+    valid = np.ones((1, 2), dtype=bool)
+
+    label, _ = sar_model.postprocess(probability, (1, 2), valid, sar_model_spec_stub)
+
+    assert sar_model_spec_stub.water_class_indices == [1]
+    assert label.tolist() == [[1, 0]]
+
+
+# ---------------------------------------------------------------------------
+# Scene / site helpers
+# ---------------------------------------------------------------------------
+
+
+def test_output_stem_matches_the_tensorflow_zoo_convention():
+    """The stem must stay {date}_RGB_S1 so npz lookups keep matching."""
+    assert (
+        sar_model._output_stem("2023-05-01-04-26-29_S1_site_VV.tif")
+        == "2023-05-01-04-26-29_RGB_S1"
+    )
+
+
+def test_output_stem_keeps_duplicate_suffix():
+    """Duplicate acquisitions must not overwrite each other's artifacts."""
+    assert (
+        sar_model._output_stem("2023-05-01-04-26-29_S1_site_VV_dup0.tif")
+        == "2023-05-01-04-26-29_RGB_S1_dup0"
+    )
+
+
+def test_collect_sar_scenes_pairs_polarizations(sar_scene_tifs):
+    scenes = sar_model.collect_sar_scenes(sar_scene_tifs["site"])
+    assert len(scenes) == 1
+    (paths,) = scenes.values()
+    assert set(paths) == {"VV", "VH"}
+
+
+def test_collect_sar_scenes_on_a_legacy_site(sar_site_vh_only):
+    scenes = sar_model.collect_sar_scenes(sar_site_vh_only["site"])
+    (paths,) = scenes.values()
+    assert set(paths) == {"VH"}
+
+
+def test_polarization_token_is_not_confused_by_a_sitename():
+    """A sitename containing 'VH' must not be read as a polarization token."""
+    assert sar_model.get_polarization_from_filename("2023_S1_myVHsite_VV.tif") == "VV"
+
+
+# ---------------------------------------------------------------------------
+# Nodata helper
+# ---------------------------------------------------------------------------
+
+
+def test_sar_nodata_mask_reports_the_empty_part_of_the_swath(sar_scene_tifs):
+    mask = sar_model.sar_nodata_mask([sar_scene_tifs["vv"], sar_scene_tifs["vh"]])
+    height, width = sar_scene_tifs["shape"]
+    assert mask.shape == (height, width)
+    assert int(mask.sum()) == sar_scene_tifs["nodata_rows"] * width
+
+
+def test_sar_nodata_mask_returns_none_when_unreadable(tmp_path):
+    assert sar_model.sar_nodata_mask([str(tmp_path / "missing.tif")]) is None
+
+
+# ---------------------------------------------------------------------------
+# Real inference
+# ---------------------------------------------------------------------------
+
+
+@requires_model
+def test_real_model_separates_water_from_land(sar_scene_tifs):
+    """Low-backscatter pixels come back as water and high-backscatter ones as land."""
+    spec = sar_model.load_sar_model_spec(SAR_MODEL_DIR)
+    prediction = sar_model.segment_scene(
+        [sar_scene_tifs["vv"], sar_scene_tifs["vh"]], spec
+    )
+
+    height, width = sar_scene_tifs["shape"]
+    valid_rows = height - sar_scene_tifs["nodata_rows"]
+
+    assert prediction.label.shape == (height, width)
+    assert set(np.unique(prediction.label).tolist()) <= {0, 1, 255}
+    assert (prediction.label[:valid_rows, : width // 2] == 1).mean() > 0.9
+    assert (prediction.label[:valid_rows, width // 2 :] == 1).mean() < 0.1

--- a/tests/test_sar_model_download.py
+++ b/tests/test_sar_model_download.py
@@ -1,0 +1,148 @@
+"""Tests for how the zoo SAR workflow obtains its ONNX model.
+
+The model is not shipped with CoastSeg -- it is ~130 MB and ``models/**/*.onnx`` is
+gitignored, so a fresh clone has none. ``find_sar_onnx_file`` downloads it from Hugging
+Face on first use, deferring to ``coastsat.SDS_sar_model`` so both SAR workflows share
+one sha256-pinned pooch cache instead of keeping a copy each.
+
+Nothing here touches the network: coastsat's resolver and fetcher are both stubbed. A
+test that reached Hugging Face would download 130 MB per run.
+"""
+
+import os
+
+import pytest
+from coastsat import SDS_sar_model
+
+from coastseg import sar_model
+
+
+@pytest.fixture(autouse=True)
+def no_real_downloads(monkeypatch, tmp_path):
+    """Make the default model look absent and the download explode.
+
+    Autouse so a test that accidentally reaches the download path fails loudly instead
+    of silently pulling 130 MB. Tests that mean to download override these.
+    """
+    monkeypatch.setattr(
+        SDS_sar_model, "get_sar_model_path", lambda *a, **k: str(tmp_path / "absent.onnx")
+    )
+
+    def explode():
+        raise AssertionError("the test tried to download the real SAR model")
+
+    monkeypatch.setattr(SDS_sar_model, "fetch_default_sar_model", explode)
+
+
+@pytest.fixture
+def fake_download(monkeypatch, tmp_path):
+    """Stand in for the Hugging Face fetch, recording that it was called."""
+    calls = []
+    cached = tmp_path / "cache" / "SAR_3_band_model.onnx"
+    cached.parent.mkdir(parents=True, exist_ok=True)
+    cached.write_bytes(b"onnx")
+
+    def fetch():
+        calls.append(True)
+        return str(cached)
+
+    monkeypatch.setattr(SDS_sar_model, "fetch_default_sar_model", fetch)
+    return {"calls": calls, "path": str(cached)}
+
+
+# ---------------------------------------------------------------------------
+# A local copy always wins
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_model_is_used_without_downloading(tmp_path, fake_download):
+    """A retrained or manually placed model must never be silently replaced by the
+    default one, and an offline machine that already has a model must keep working."""
+    local = tmp_path / "SAR_segmentation_model"
+    local.mkdir()
+    (local / "my_retrained.onnx").write_bytes(b"local")
+
+    resolved = sar_model.find_sar_onnx_file(str(local))
+
+    assert resolved == str((local / "my_retrained.onnx").resolve())
+    assert fake_download["calls"] == []
+
+
+def test_an_already_cached_default_is_not_re_downloaded(monkeypatch, tmp_path):
+    """The second run must not re-fetch: coastsat's resolver already points at the
+    cached copy, whichever workflow put it there."""
+    cached = tmp_path / "SAR_3_band_model.onnx"
+    cached.write_bytes(b"onnx")
+    monkeypatch.setattr(SDS_sar_model, "get_sar_model_path", lambda *a, **k: str(cached))
+
+    # fetch_default_sar_model is still the exploding stub from the autouse fixture
+    resolved = sar_model.find_sar_onnx_file(str(tmp_path / "empty_dir"))
+
+    assert resolved == os.path.abspath(str(cached))
+
+
+# ---------------------------------------------------------------------------
+# Downloading when there is nothing on disk
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_model_directory_downloads_the_default(tmp_path, fake_download):
+    empty = tmp_path / sar_model.DEFAULT_SAR_MODEL_DIRNAME
+    empty.mkdir()
+
+    resolved = sar_model.find_sar_onnx_file(str(empty))
+
+    assert resolved == fake_download["path"]
+    assert fake_download["calls"] == [True]
+
+
+def test_a_missing_model_directory_downloads_the_default(tmp_path, fake_download):
+    """A fresh clone has no models/SAR_segmentation_model directory at all."""
+    resolved = sar_model.find_sar_onnx_file(
+        str(tmp_path / "never_created" / sar_model.DEFAULT_SAR_MODEL_DIRNAME)
+    )
+
+    assert resolved == fake_download["path"]
+    assert fake_download["calls"] == [True]
+
+
+def test_download_is_skippable(tmp_path):
+    """download=False keeps the old fail-fast behaviour for callers that want it."""
+    with pytest.raises(FileNotFoundError, match="No .onnx file"):
+        sar_model.find_sar_onnx_file(str(tmp_path), download=False)
+
+
+# ---------------------------------------------------------------------------
+# Failure is actionable
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_download_explains_how_to_do_it_by_hand(monkeypatch, tmp_path):
+    """Offline, behind a proxy, or Hugging Face down: the user needs the URL and the
+    destination, not just 'download failed'."""
+
+    def fail():
+        raise SDS_sar_model.SarModelUnavailable("no internet")
+
+    monkeypatch.setattr(SDS_sar_model, "fetch_default_sar_model", fail)
+
+    with pytest.raises(sar_model.SarModelError) as error:
+        sar_model.find_sar_onnx_file(str(tmp_path / "empty"))
+
+    message = str(error.value)
+    assert "no internet" in message
+    assert "huggingface.co" in message
+    assert sar_model.DEFAULT_SAR_MODEL_DIRNAME in message
+
+
+def test_the_download_failure_is_a_coastseg_error(monkeypatch, tmp_path):
+    """Callers catch coastseg.sar_model.SarModelError; coastsat's exception type must
+    not leak out of this module."""
+
+    def fail():
+        raise SDS_sar_model.SarModelUnavailable("nope")
+
+    monkeypatch.setattr(SDS_sar_model, "fetch_default_sar_model", fail)
+
+    with pytest.raises(sar_model.SarModelError):
+        sar_model.find_sar_onnx_file(str(tmp_path / "empty"))

--- a/tests/test_sar_npz_contract.py
+++ b/tests/test_sar_npz_contract.py
@@ -1,0 +1,371 @@
+"""Tests for the artifacts the SAR path writes into a session directory.
+
+Shoreline extraction is model-agnostic: it only knows how to read `_res.npz` files and
+`model_info.json`. These tests pin that contract so the SAR segmenter's output stays
+consumable without any changes downstream.
+
+Inference is stubbed, so none of this loads the real 130 MB model.
+"""
+
+import json
+import os
+
+import numpy as np
+import pytest
+
+from coastseg import common, extracted_shoreline, sar_model
+from coastseg.model_info import ModelInfo
+
+
+# Column boundary the stub predicts water to the left of. Chosen to sit inside the
+# unpadded 70-pixel-wide fixture so the assertions do not depend on the padded width.
+WATER_COLUMNS = 20
+
+
+class StubSession:
+    """Stands in for an onnxruntime session: water left of WATER_COLUMNS, land right."""
+
+    def __init__(self):
+        self.calls = []
+
+    def run(self, output_names, feed):
+        (tensor,) = feed.values()
+        self.calls.append(tensor.shape)
+        _, _, height, width = tensor.shape
+        probability = np.zeros((1, 1, height, width), dtype=np.float32)
+        probability[:, :, :, :WATER_COLUMNS] = 0.99
+        return [probability]
+
+
+@pytest.fixture
+def stubbed_sar(monkeypatch, sar_model_spec_stub):
+    """Run the batch driver without coastsat or the real model."""
+    session = StubSession()
+    monkeypatch.setattr(
+        sar_model, "load_sar_model_spec", lambda *a, **k: sar_model_spec_stub
+    )
+    monkeypatch.setattr(sar_model, "get_session", lambda *a, **k: session)
+    return session
+
+
+def run_segmentation(tmp_path, site, **kwargs):
+    return sar_model.run_sar_segmentation(
+        roi_directory=site,
+        session_directory=str(tmp_path / "session"),
+        model_directory=str(tmp_path / "model"),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_writes_the_expected_artifact_set(tmp_path, sar_scene_tifs, stubbed_sar):
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+    written = sorted(os.listdir(summary["session_directory"]))
+
+    assert written == [
+        "2023-05-01-04-26-29_RGB_S1_predseg.png",
+        "2023-05-01-04-26-29_RGB_S1_res.npz",
+        "model_info.json",
+        "model_settings.json",
+        "segmentation_summary.json",
+    ]
+    assert summary["total_images"] == 1
+    assert summary["written_npz"] == 1
+    assert summary["failures"] == []
+
+
+def test_npz_keys_and_dtypes(tmp_path, sar_scene_tifs, stubbed_sar):
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+    npz_path = os.path.join(
+        summary["session_directory"], "2023-05-01-04-26-29_RGB_S1_res.npz"
+    )
+    data = np.load(npz_path, allow_pickle=True)
+
+    assert data["grey_label"].dtype == np.uint8
+    assert set(np.unique(data["grey_label"]).tolist()) <= {0, 1, 255}
+    assert data["grey_label"].shape == sar_scene_tifs["shape"]
+    assert int(data["n_data_bands"]) == 3
+    assert data["classes_to_index"].item() == {0: "land", 1: "water"}
+
+
+def test_nclasses_is_the_class_count_not_the_max_label(
+    tmp_path, sar_scene_tifs, stubbed_sar
+):
+    """Deriving nclasses from label.max() + 1 would give 256 once nodata is present."""
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+    data = np.load(
+        os.path.join(summary["session_directory"], "2023-05-01-04-26-29_RGB_S1_res.npz"),
+        allow_pickle=True,
+    )
+
+    assert int(data["nclasses"]) == 2
+    assert 255 in np.unique(data["grey_label"])
+
+
+def test_probability_is_stored_with_nan_at_nodata(tmp_path, sar_scene_tifs, stubbed_sar):
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+    data = np.load(
+        os.path.join(summary["session_directory"], "2023-05-01-04-26-29_RGB_S1_res.npz"),
+        allow_pickle=True,
+    )
+    nodata_mask = data["nodata_mask"]
+
+    assert data["av_softmax_scores"].dtype == np.float32
+    assert np.all(np.isnan(data["av_softmax_scores"][nodata_mask]))
+    assert not np.any(np.isnan(data["av_softmax_scores"][~nodata_mask]))
+
+
+def test_predseg_png_is_written_for_the_segmentation_filter(
+    tmp_path, sar_scene_tifs, stubbed_sar
+):
+    """apply_segmentation_filter globs for images and pairs them with the npz."""
+    from PIL import Image
+
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+    png_path = os.path.join(
+        summary["session_directory"], "2023-05-01-04-26-29_RGB_S1_predseg.png"
+    )
+    image = np.array(Image.open(png_path))
+
+    assert image.shape == sar_scene_tifs["shape"] + (3,)
+    # nodata rows are rendered black
+    assert np.all(image[-sar_scene_tifs["nodata_rows"] :, :, :] == 0)
+
+
+# ---------------------------------------------------------------------------
+# The water threshold setting
+# ---------------------------------------------------------------------------
+
+
+class GradedSession:
+    """Predicts a middling P(water) so the cutoff decides the label, not the model."""
+
+    def run(self, output_names, feed):
+        (tensor,) = feed.values()
+        _, _, height, width = tensor.shape
+        probability = np.full((1, 1, height, width), 0.6, dtype=np.float32)
+        return [probability]
+
+
+@pytest.fixture
+def graded_sar(monkeypatch, sar_model_spec_stub):
+    monkeypatch.setattr(
+        sar_model, "load_sar_model_spec", lambda *a, **k: sar_model_spec_stub
+    )
+    monkeypatch.setattr(sar_model, "get_session", lambda *a, **k: GradedSession())
+
+
+def water_fraction_at(tmp_path, site, session_name, **kwargs):
+    """Segment the site into its own session and return (water fraction, threshold)."""
+    summary = sar_model.run_sar_segmentation(
+        roi_directory=site,
+        session_directory=str(tmp_path / session_name),
+        model_directory=str(tmp_path / "model"),
+        **kwargs,
+    )
+    data = np.load(
+        os.path.join(summary["session_directory"], "2023-05-01-04-26-29_RGB_S1_res.npz"),
+        allow_pickle=True,
+    )
+    label = data["grey_label"]
+    valid = label != 255
+    return float(np.mean(label[valid] == 1)), float(data["water_threshold"])
+
+
+def test_the_model_metadata_threshold_is_used_when_none_is_supplied(
+    tmp_path, sar_scene_tifs, graded_sar
+):
+    fraction, threshold = water_fraction_at(tmp_path, sar_scene_tifs["site"], "default")
+
+    assert threshold == pytest.approx(0.5)  # stored float32, so compare loosely
+    assert fraction == 1.0  # P(water)=0.6 clears a 0.5 cutoff everywhere
+
+
+def test_the_supplied_threshold_overrides_the_model_metadata(
+    tmp_path, sar_scene_tifs, graded_sar
+):
+    """The user's sar_water_threshold has to reach the batch path.
+
+    It used to be dropped on the way through Zoo_Model.run_model, leaving the cutoff
+    pinned at whatever the .onnx recorded while the npz claimed otherwise.
+    """
+    fraction, threshold = water_fraction_at(
+        tmp_path, sar_scene_tifs["site"], "strict", water_threshold=0.8
+    )
+
+    assert threshold == pytest.approx(0.8)
+    assert fraction == 0.0  # the same P(water)=0.6 now falls short
+
+
+def test_zoo_model_forwards_the_water_threshold_setting(monkeypatch, tmp_path):
+    """Zoo_Model.run_model must pass the setting down rather than dropping it."""
+    captured = {}
+    monkeypatch.setattr(
+        sar_model,
+        "run_sar_segmentation",
+        lambda **kwargs: captured.update(kwargs)
+        or {"written_npz": 0, "total_images": 0, "failures": []},
+    )
+
+    from coastseg import zoo_model as zoo
+
+    model = zoo.Zoo_Model()
+    monkeypatch.setattr(
+        model, "resolve_model_directory", lambda setting: str(tmp_path / "sar_dir")
+    )
+    monkeypatch.setattr(sar_model, "is_sar_model_directory", lambda directory: True)
+
+    model.run_model(
+        {"sar_water_threshold": 0.75},
+        "sample_directory",
+        "session_directory",
+        roi_directory="roi",
+    )
+
+    assert captured["water_threshold"] == 0.75
+
+
+# ---------------------------------------------------------------------------
+# Downstream consumers
+# ---------------------------------------------------------------------------
+
+
+def test_load_merged_image_labels_returns_the_water_mask(
+    tmp_path, sar_scene_tifs, stubbed_sar
+):
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+    npz_path = os.path.join(
+        summary["session_directory"], "2023-05-01-04-26-29_RGB_S1_res.npz"
+    )
+
+    water = extracted_shoreline.load_merged_image_labels(npz_path, class_indices=[1])
+    height, width = sar_scene_tifs["shape"]
+    valid_rows = height - sar_scene_tifs["nodata_rows"]
+
+    assert water.shape == (height, width)
+    assert water[:valid_rows, :WATER_COLUMNS].all()
+    assert not water[:valid_rows, WATER_COLUMNS:].any()
+    # nodata must never be counted as water
+    assert not water[valid_rows:, :].any()
+
+
+def test_find_matching_npz_resolves_from_the_vv_filename(
+    tmp_path, sar_scene_tifs, stubbed_sar
+):
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+    match = extracted_shoreline.find_matching_npz(
+        os.path.basename(sar_scene_tifs["vv"]), summary["session_directory"]
+    )
+    assert match is not None
+    assert match.endswith("2023-05-01-04-26-29_RGB_S1_res.npz")
+
+
+def test_get_filtered_dates_dict_sees_the_sar_session(
+    tmp_path, sar_scene_tifs, stubbed_sar
+):
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+    dates = common.get_filtered_dates_dict(summary["session_directory"], "npz")
+    assert dates["S1"] == {"2023-05-01-04-26-29"}
+
+
+def test_model_info_json_round_trips_through_model_info(
+    tmp_path, sar_scene_tifs, stubbed_sar
+):
+    summary = run_segmentation(
+        tmp_path, sar_scene_tifs["site"], rgb_directory=sar_scene_tifs["rgb_directory"]
+    )
+    info = ModelInfo(
+        model_info_path=os.path.join(summary["session_directory"], "model_info.json")
+    )
+    info.load_from_model_info_file()
+
+    assert info.class_mapping == {0: "land", 1: "water"}
+    assert info.water_class_indices == [1]
+    assert info.input_directory == sar_scene_tifs["rgb_directory"]
+
+
+def test_model_settings_json_records_the_sar_image_type(
+    tmp_path, sar_scene_tifs, stubbed_sar
+):
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+    settings = json.loads(
+        open(
+            os.path.join(summary["session_directory"], "model_settings.json"),
+            encoding="utf-8",
+        ).read()
+    )
+    assert settings["img_type"] == "SAR"
+    assert settings["model_type"] == "model"
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_vh_only_site_names_the_missing_polarizations(
+    tmp_path, sar_site_vh_only, stubbed_sar
+):
+    with pytest.raises(sar_model.MissingPolarizationError) as error:
+        run_segmentation(tmp_path, sar_site_vh_only["site"])
+
+    assert "['VV', 'VH']" in str(error.value)
+
+
+def test_legacy_vh_only_advice_says_to_re_run_the_download(
+    tmp_path, sar_site_vh_only, stubbed_sar
+):
+    """coastsat backfills the missing band on the next download, so the error tells the
+    user to re-run it. Telling them to re-download to a new sitename instead would cost
+    them a full download for nothing."""
+    with pytest.raises(sar_model.MissingPolarizationError) as error:
+        run_segmentation(tmp_path, sar_site_vh_only["site"])
+
+    message = str(error.value).lower()
+    assert "re-run the download" in message
+    assert "new sitename" not in message
+
+
+def test_scenes_missing_a_polarization_are_recorded_not_fatal(
+    tmp_path, sar_scene_tifs, sar_tif_writer, stubbed_sar
+):
+    """A site with one complete and one incomplete scene segments what it can."""
+    build_sar_bands, write_sar_tif = sar_tif_writer
+
+    _, vh = build_sar_bands(nodata_rows=0)
+    write_sar_tif(
+        os.path.join(
+            sar_scene_tifs["site"], "S1", "VH", "2024-06-02-04-26-29_S1_test_VH.tif"
+        ),
+        vh,
+    )
+
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"])
+
+    assert summary["total_images"] == 1
+    assert summary["written_npz"] == 1
+    assert len(summary["failures"]) == 1
+    assert "VV" in summary["failures"][0]["error"]
+
+
+def test_overwrite_false_skips_existing_artifacts(
+    tmp_path, sar_scene_tifs, stubbed_sar
+):
+    run_segmentation(tmp_path, sar_scene_tifs["site"])
+    summary = run_segmentation(tmp_path, sar_scene_tifs["site"], overwrite=False)
+
+    assert summary["skipped_existing"] == 1
+    assert summary["written_npz"] == 0
+
+
+def test_filenames_argument_restricts_the_scenes_processed(
+    tmp_path, sar_scene_tifs, stubbed_sar
+):
+    summary = run_segmentation(
+        tmp_path, sar_scene_tifs["site"], filenames=["1999-01-01-00-00-00_S1_test_VV.tif"]
+    )
+    assert summary["total_images"] == 0

--- a/tests/test_sar_otsu_fallback_warning.py
+++ b/tests/test_sar_otsu_fallback_warning.py
@@ -1,0 +1,159 @@
+"""Tests for the warnings CoastSeg raises when SAR shorelines are not model-segmented.
+
+coastsat never raises when the SAR segmentation model is unusable -- ``load_sar_segmenter``
+returns None and every scene is thresholded with the legacy Otsu method instead. The run
+still produces shorelines, so nothing looks wrong, and coastsat records the fallback only
+in its own log inside the session folder. These tests pin the two places CoastSeg surfaces
+it to the user:
+
+1. a pre-flight check, before extraction, for the whole-run fallback, and
+2. a post-run tally of ``output['segmentation_method']``, which also catches the per-scene
+   fallbacks the pre-flight check cannot predict.
+
+Nothing here loads the real ~130 MB ONNX model: the segmenter is stubbed.
+"""
+
+import numpy as np
+import pytest
+from coastsat import SDS_shoreline, SDS_tools
+
+from coastseg import extracted_shoreline as es
+
+S1_METADATA = {"S1": {"dates": ["2023-05-06-02-07-48"]}}
+
+
+@pytest.fixture
+def segmenter(monkeypatch):
+    """Control what coastsat's load_sar_segmenter returns without touching the model."""
+
+    def set_result(result):
+        monkeypatch.setattr(
+            SDS_shoreline, "load_sar_segmenter", lambda *a, **k: result
+        )
+
+    return set_result
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight check
+# ---------------------------------------------------------------------------
+
+
+def test_an_unusable_model_warns_that_the_whole_run_falls_back(
+    caplog, capsys, segmenter
+):
+    """The silent degrade is the whole point: a user who is not told keeps the worse
+    shorelines and never knows the model was skipped."""
+    segmenter(None)
+
+    with caplog.at_level("WARNING"):
+        fell_back = es.warn_if_sar_falls_back_to_otsu({}, S1_METADATA)
+
+    assert fell_back is True
+    assert "falls back to the legacy Otsu threshold" in caplog.text
+    # printed too -- a notebook user does not read the logger
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_a_loadable_model_says_nothing(caplog, segmenter):
+    segmenter(("session", {"channel_order": ["VV", "VH", "VV-VH"]}))
+
+    with caplog.at_level("WARNING"):
+        assert es.warn_if_sar_falls_back_to_otsu({}, S1_METADATA) is False
+
+    assert caplog.text == ""
+
+
+def test_asking_for_otsu_is_not_a_warning(caplog, capsys, segmenter):
+    """Otsu chosen deliberately is a valid configuration, not a degraded run. Warning
+    about it would train users to ignore the warning that matters."""
+    segmenter(None)
+
+    with caplog.at_level("INFO"):
+        assert (
+            es.warn_if_sar_falls_back_to_otsu(
+                {"sar_segmentation": "otsu"}, S1_METADATA
+            )
+            is False
+        )
+
+    assert "WARNING" not in capsys.readouterr().out
+    assert "thresholded rather than segmented" in caplog.text
+
+
+@pytest.mark.parametrize("metadata", [{}, {"S2": {"dates": ["2023-05-06"]}}])
+def test_an_optical_only_run_never_loads_the_sar_model(caplog, monkeypatch, metadata):
+    """No S1 scenes means the SAR model is irrelevant, and loading a ~130 MB model to
+    discover that would cost every optical run real time."""
+
+    def explode(*args, **kwargs):
+        raise AssertionError("the SAR model must not be loaded for an optical run")
+
+    monkeypatch.setattr(SDS_shoreline, "load_sar_segmenter", explode)
+
+    with caplog.at_level("WARNING"):
+        assert es.warn_if_sar_falls_back_to_otsu({}, metadata) is False
+
+    assert caplog.text == ""
+
+
+# ---------------------------------------------------------------------------
+# Post-run tally
+# ---------------------------------------------------------------------------
+
+
+def test_a_per_scene_fallback_is_reported_after_the_run(caplog, capsys):
+    """A scene coastsat could not segment drops to Otsu on its own, which the pre-flight
+    check cannot predict."""
+    output = {
+        "segmentation_method": [
+            SDS_tools.SEGMENTATION_SAR_MODEL,
+            SDS_tools.SEGMENTATION_SAR_OTSU,
+            SDS_tools.SEGMENTATION_SAR_MODEL,
+        ]
+    }
+
+    with caplog.at_level("WARNING"):
+        counts = es.report_sar_segmentation_methods(output)
+
+    assert counts == {
+        SDS_tools.SEGMENTATION_SAR_MODEL: 2,
+        SDS_tools.SEGMENTATION_SAR_OTSU: 1,
+    }
+    assert "1 of 3" in caplog.text
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_a_fully_model_segmented_run_does_not_warn(caplog, capsys):
+    output = {
+        "segmentation_method": [SDS_tools.SEGMENTATION_SAR_MODEL] * 3
+    }
+
+    with caplog.at_level("INFO"):
+        counts = es.report_sar_segmentation_methods(output)
+
+    assert counts[SDS_tools.SEGMENTATION_SAR_OTSU] == 0
+    assert "WARNING" not in capsys.readouterr().out
+    assert "All 3 Sentinel-1 shorelines" in caplog.text
+
+
+def test_an_optical_only_output_is_not_reported_on(caplog, capsys):
+    """Optical shorelines carry 'mndwi' and must not be counted as SAR."""
+    output = {"segmentation_method": [SDS_tools.SEGMENTATION_MNDWI] * 4}
+
+    with caplog.at_level("INFO"):
+        counts = es.report_sar_segmentation_methods(output)
+
+    assert counts == {
+        SDS_tools.SEGMENTATION_SAR_MODEL: 0,
+        SDS_tools.SEGMENTATION_SAR_OTSU: 0,
+    }
+    assert capsys.readouterr().out == ""
+
+
+def test_output_without_the_column_is_handled():
+    """CoastSeg's own zoo extraction records no SAR methods; this must not raise."""
+    assert es.report_sar_segmentation_methods({}) == {
+        SDS_tools.SEGMENTATION_SAR_MODEL: 0,
+        SDS_tools.SEGMENTATION_SAR_OTSU: 0,
+    }

--- a/tests/test_sar_settings.py
+++ b/tests/test_sar_settings.py
@@ -1,0 +1,198 @@
+"""Tests for the Sentinel-1 download settings and on-disk layout.
+
+The SAR model needs both VV and VH, so these pin that the default requests both, that
+the setting survives a config round-trip, and that the polarization folders are found.
+"""
+
+import json
+import os
+
+import pytest
+
+from coastseg import common, extracted_shoreline
+
+
+def make_selected_rois(*roi_ids):
+    return {
+        "features": [
+            {
+                "properties": {"id": roi_id},
+                "geometry": {"coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]},
+            }
+            for roi_id in roi_ids
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_sentinel_1_properties_request_both_polarizations():
+    properties = common.get_default_sentinel_1_properties()
+    assert properties["transmitterReceiverPolarisation"] == ["VV", "VH"]
+    assert properties["instrumentMode"] == "IW"
+
+
+def test_create_roi_settings_defaults_to_vv_and_vh():
+    roi_settings = common.create_roi_settings(
+        settings={"sat_list": ["S1"], "dates": ["2023-05-01", "2023-06-01"]},
+        selected_rois=make_selected_rois("1"),
+        filepath="/data",
+        date_str="01-01-25__00_00_00",
+    )
+    assert roi_settings["1"]["sentinel_1_properties"][
+        "transmitterReceiverPolarisation"
+    ] == ["VV", "VH"]
+
+
+def test_create_roi_settings_gives_each_roi_its_own_properties_dict():
+    """A shared mutable dict would let an edit to one ROI silently change every ROI."""
+    roi_settings = common.create_roi_settings(
+        settings={"sat_list": ["S1"], "dates": ["2023-05-01", "2023-06-01"]},
+        selected_rois=make_selected_rois("1", "2"),
+        filepath="/data",
+        date_str="01-01-25__00_00_00",
+    )
+
+    first = roi_settings["1"]["sentinel_1_properties"]
+    second = roi_settings["2"]["sentinel_1_properties"]
+    assert first is not second
+
+    first["transmitterReceiverPolarisation"].append("HH")
+    assert second["transmitterReceiverPolarisation"] == ["VV", "VH"]
+
+
+def test_create_roi_settings_honours_an_explicit_override():
+    roi_settings = common.create_roi_settings(
+        settings={
+            "sat_list": ["S1"],
+            "dates": ["2023-05-01", "2023-06-01"],
+            "sentinel_1_properties": {
+                "transmitterReceiverPolarisation": ["VH"],
+                "instrumentMode": "IW",
+            },
+        },
+        selected_rois=make_selected_rois("1"),
+        filepath="/data",
+        date_str="01-01-25__00_00_00",
+    )
+    assert roi_settings["1"]["sentinel_1_properties"][
+        "transmitterReceiverPolarisation"
+    ] == ["VH"]
+
+
+# ---------------------------------------------------------------------------
+# Config round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_extract_roi_settings_keeps_sentinel_1_properties():
+    """Without this the setting is dropped whenever a session config is reloaded."""
+    properties = {
+        "transmitterReceiverPolarisation": ["VV", "VH"],
+        "instrumentMode": "IW",
+    }
+    json_data = {
+        "roi_ids": ["1"],
+        "1": {
+            "dates": ["2023-05-01", "2023-06-01"],
+            "sitename": "ID_1_datetime01-01-25__00_00_00",
+            "polygon": [[[0, 0]]],
+            "roi_id": "1",
+            "sat_list": ["S1"],
+            "landsat_collection": "C02",
+            "filepath": "/data",
+            "sentinel_1_properties": properties,
+        },
+    }
+
+    roi_settings = common.extract_roi_settings(json_data)
+    assert roi_settings["1"]["sentinel_1_properties"] == properties
+
+
+def test_load_settings_keeps_sentinel_1_properties(tmp_path):
+    properties = {
+        "transmitterReceiverPolarisation": ["VV", "VH"],
+        "instrumentMode": "IW",
+    }
+    config = tmp_path / "config.json"
+    config.write_text(
+        json.dumps({"sat_list": ["S1"], "sentinel_1_properties": properties}),
+        encoding="utf-8",
+    )
+
+    settings = common.load_settings(str(config))
+    assert settings["sentinel_1_properties"] == properties
+
+
+def test_global_settings_upgrade_a_legacy_roi_without_the_key():
+    """Legacy ROI settings have no sentinel_1_properties key at all.
+
+    update_roi_settings skips keys that are absent, so without add_if_missing the ROI
+    would stay on coastsat's VH-only fallback forever.
+    """
+    roi_settings = {"1": {"sat_list": ["S1"], "dates": ["2023-05-01", "2023-06-01"]}}
+    global_settings = {
+        "sat_list": ["S1"],
+        "dates": ["2023-05-01", "2023-06-01"],
+        "sentinel_1_properties": {
+            "transmitterReceiverPolarisation": ["VV", "VH"],
+            "instrumentMode": "IW",
+        },
+    }
+
+    updated = common.update_roi_settings_with_global_settings(
+        roi_settings, global_settings
+    )
+    assert updated["1"]["sentinel_1_properties"][
+        "transmitterReceiverPolarisation"
+    ] == ["VV", "VH"]
+
+
+def test_global_settings_propagation_does_not_alias_the_global_dict():
+    global_settings = {
+        "sentinel_1_properties": {"transmitterReceiverPolarisation": ["VV", "VH"]}
+    }
+    roi_settings = {"1": {"sat_list": ["S1"]}}
+
+    updated = common.update_roi_settings_with_global_settings(
+        roi_settings, global_settings
+    )
+    updated["1"]["sentinel_1_properties"]["transmitterReceiverPolarisation"].append("HH")
+
+    assert global_settings["sentinel_1_properties"][
+        "transmitterReceiverPolarisation"
+    ] == ["VV", "VH"]
+
+
+# ---------------------------------------------------------------------------
+# On-disk layout
+# ---------------------------------------------------------------------------
+
+
+def test_get_filepath_returns_every_polarization_in_canonical_order(tmp_path):
+    site = "ID_test_datetime01-01-25__00_00_00"
+    # created out of order on purpose: the result must not depend on listdir order
+    os.makedirs(tmp_path / site / "S1" / "VH")
+    os.makedirs(tmp_path / site / "S1" / "VV")
+
+    paths = extracted_shoreline.get_filepath(str(tmp_path), site, "S1")
+
+    assert [os.path.basename(path) for path in paths] == ["VV", "VH"]
+
+
+def test_get_filepath_on_a_legacy_vh_only_site(tmp_path):
+    site = "ID_legacy_datetime01-01-20__00_00_00"
+    os.makedirs(tmp_path / site / "S1" / "VH")
+
+    paths = extracted_shoreline.get_filepath(str(tmp_path), site, "S1")
+
+    assert [os.path.basename(path) for path in paths] == ["VH"]
+
+
+def test_get_filepath_when_nothing_is_downloaded_yet(tmp_path):
+    """Keep the legacy single-element shape so callers fail the way they always did."""
+    paths = extracted_shoreline.get_filepath(str(tmp_path), "ID_missing", "S1")
+    assert [os.path.basename(path) for path in paths] == ["VH"]

--- a/tests/test_segmentation_workflow_model_info_json.py
+++ b/tests/test_segmentation_workflow_model_info_json.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "segmentation_workflow"
+    / "run_zoo_segmentation_models.py"
+)
+
+
+def _load_standalone_module(monkeypatch) -> object:
+    fake_logger = types.SimpleNamespace(setLevel=lambda *_args, **_kwargs: None)
+    fake_tf = types.SimpleNamespace(
+        get_logger=lambda: fake_logger,
+        config=types.SimpleNamespace(
+            set_visible_devices=lambda *_args, **_kwargs: None
+        ),
+    )
+
+    fake_transformers = types.SimpleNamespace(TFSegformerForSemanticSegmentation=object)
+
+    monkeypatch.setitem(sys.modules, "tensorflow", fake_tf)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+    module_name = "test_segmentation_workflow_model_info_module"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_write_model_info_json_contains_expected_fields(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_standalone_module(monkeypatch)
+
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    model_dir = tmp_path / "model"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    model_dir.mkdir()
+
+    config = module.SegmentationConfig(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        model_path=str(model_dir),
+    )
+    model_spec = module.ModelSpec(
+        model=None,
+        model_type="segformer",
+        target_size=(512, 512),
+        nclasses=4,
+        class_mapping={0: "water", 1: "whitewater", 2: "sediment", 3: "other"},
+    )
+    backend = module.InferenceBackend(models=(model_spec,))
+
+    model_info_path = module._write_model_info_json(config, backend)
+
+    assert model_info_path.exists()
+    payload = json.loads(model_info_path.read_text(encoding="utf-8"))
+
+    assert payload["model_directory"] == str(model_dir.resolve())
+    assert payload["input_directory"] == str(input_dir)
+    assert payload["class_mapping"] == {
+        "0": "water",
+        "1": "whitewater",
+        "2": "sediment",
+        "3": "other",
+    }
+    assert payload["water_class_indices"] == [0, 1]
+    assert payload["water_classes"] == ["water", "whitewater"]
+
+
+def test_write_model_settings_json_contains_expected_fields(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_standalone_module(monkeypatch)
+
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    model_dir = tmp_path / "global_segformer_RGB_4class_14036903"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    model_dir.mkdir()
+
+    config = module.SegmentationConfig(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        model_path=str(model_dir),
+        implementation="best",
+        use_gpu=False,
+    )
+
+    model_settings_path = module._write_model_settings_json(config)
+    assert model_settings_path.exists()
+
+    payload = json.loads(model_settings_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "use_GPU": "0",
+        "implementation": "BEST",
+        "model_type": "global_segformer_RGB_4class_14036903",
+        "img_type": "RGB",
+    }


### PR DESCRIPTION
Release the new coastseg package v2.0.4. This release uses the new coastsat-package v0.5.0 enhanced SAR shoreline mapping workflow. This new workflow allows the user to download VV bands in addition to the VH bands. It also includes the ability to use a new 3 band SAR model (VV,VH,VV-VH) to better extract shorelines from imagery. This PR overhauls the coastsat and zoo workflow to be able to use this new SAR workflow. The SAR workflow now defaults to this new workflow.